### PR TITLE
enable multiple dynamic key replacements in scenario outline

### DIFF
--- a/examples/typescript/specs/features/scenario-outlines.feature
+++ b/examples/typescript/specs/features/scenario-outlines.feature
@@ -1,6 +1,6 @@
 Feature: Online sales
 
-Scenario Outline: Selling an <Item>
+Scenario Outline: Selling an <Item> at <Amount>$
     Given I have a(n) <Item>
     When I sell the <Item>
     Then I should get $<Amount>

--- a/examples/typescript/specs/step-definitions/scenario-outlines.steps.ts
+++ b/examples/typescript/specs/step-definitions/scenario-outlines.steps.ts
@@ -11,7 +11,7 @@ defineFeature(feature, (test) => {
         onlineSales = new OnlineSales();
     });
 
-    test('Selling an <Item>', ({ given, when, then }) => {
+    test('Selling an <Item> at <Amount>$', ({ given, when, then }) => {
         given(/^I have a\(n\) (.*)$/, (item) => {
             onlineSales.listItem(item);
         });

--- a/src/parsed-feature-loading.ts
+++ b/src/parsed-feature-loading.ts
@@ -119,20 +119,14 @@ const parseScenarioOutlineExampleSteps = (exampleTableRow: any, scenarioSteps: P
 };
 
 const getOutlineDynamicTitle = (exampleTableRow: any, title: string) => {
-    const findTitleKey = title.match(/<(.*)>/);
-    return findTitleKey && findTitleKey.length >= 1 ? findTitleKey[1] : '';
+    return title.replace(/<(\S*)>/g, (_, firstMatch) => {
+        return exampleTableRow[firstMatch || ''];
+    });
 };
 
 const parseScenarioOutlineExample = (exampleTableRow: any, outlineScenario: ParsedScenario) => {
-    const outlineScenarioTitle = outlineScenario.title;
-    const exampleKeyTitle = getOutlineDynamicTitle(exampleTableRow, outlineScenarioTitle);
-    const exampleTitle = exampleTableRow[exampleKeyTitle] ? exampleTableRow[exampleKeyTitle] : '';
-    let title = outlineScenarioTitle;
-    if (exampleKeyTitle) {
-        title = outlineScenarioTitle.replace(`<${exampleKeyTitle}>`, exampleTitle);
-    }
     return {
-        title,
+        title: getOutlineDynamicTitle(exampleTableRow, outlineScenario.title),
         steps: parseScenarioOutlineExampleSteps(exampleTableRow, outlineScenario.steps),
         tags: outlineScenario.tags,
     } as ParsedScenario;


### PR DESCRIPTION
This PR fixes an issue with having multiple dynamic keys in scenario outline. The previous behavior was to look only for one key, and with a too permissive regexp. Thus resulting in bad scenario names :

- The regexp was `<(.*)>`
- Given a title : `"some title <withOneDynamicVariable> and <anOtherDynamicVariable> in it"` and an exampleTableRow : `{ withOneDynamicVariable: 'foo', anOtherDynamicVariable: 'bar' }`
- The generated title is "some title foo in it", because the regex matches : `"<withOneDynamicVariable> and <anOtherDynamicVariable>"`

The new regexp is now `/(\S*)/g` since you can't have space in gherkin variable's name.