### PR TITLE
Global steps

### DIFF
--- a/src/code-generation/step-generation.ts
+++ b/src/code-generation/step-generation.ts
@@ -1,6 +1,7 @@
 import { globalSteps } from '../global-steps';
 import { ParsedStep } from '../models';
 import { indent } from './utils';
+import { getJestCucumberConfiguration } from '../configuration';
 
 const stepTemplate = (stepKeyword: string, stepMatcher: string, stepArgumentVariables: string[]) => {
     let template = `${stepKeyword}(${stepMatcher}`;
@@ -74,7 +75,7 @@ const getStepArguments = (step: ParsedStep) => {
 const getStepMatcher = (step: ParsedStep) => {
     let stepMatcher: string = '';
 
-    if (step.stepText.match(stepTextArgumentRegex)) {
+    if (step.stepText.match(stepTextArgumentRegex) && !getJestCucumberConfiguration().disableRegexGeneration) {
         stepMatcher = convertStepTextToRegex(step);
     } else {
         stepMatcher = `'${step.stepText.replace(/'+/g, `\\'`)}'`;

--- a/src/code-generation/step-generation.ts
+++ b/src/code-generation/step-generation.ts
@@ -1,8 +1,13 @@
+import { globalSteps } from '../global-steps';
 import { ParsedStep } from '../models';
 import { indent } from './utils';
 
 const stepTemplate = (stepKeyword: string, stepMatcher: string, stepArgumentVariables: string[]) => {
-    return `${stepKeyword}(${stepMatcher}, (${stepArgumentVariables.join(', ')}) => {\n\n});`;
+    let template = `${stepKeyword}(${stepMatcher}`;
+    if (!globalSteps.get(stepMatcher)) {
+        template = `${template}, (${stepArgumentVariables.join(', ')}) => {\n\n}`;
+    }
+    return `${template});`;
 };
 
 const getStepFunctionWrapperName = (stepKeyword: string, stepText: string) => {
@@ -11,10 +16,10 @@ const getStepFunctionWrapperName = (stepKeyword: string, stepText: string) => {
 };
 
 const stepWrapperFunctionTemplate = (
-  stepKeyword: string,
-  stepText: string,
-  stepMatcher: string,
-  stepArgumentVariables: string[],
+    stepKeyword: string,
+    stepText: string,
+    stepMatcher: string,
+    stepArgumentVariables: string[],
 ) => {
     // tslint:disable-next-line:max-line-length
     return `export const ${getStepFunctionWrapperName(stepKeyword, stepText)} = (${stepKeyword}) => {\n${indent(stepTemplate(stepKeyword, stepMatcher, stepArgumentVariables), 1).slice(0, -1)}\n}`;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,6 +10,7 @@ const defaultErrorSettings = {
 const defaultConfiguration: Options = {
     tagFilter: undefined,
     scenarioNameTemplate: undefined,
+    disableRegexGeneration: undefined,
     errors: defaultErrorSettings,
 };
 

--- a/src/feature-definition-creation.ts
+++ b/src/feature-definition-creation.ts
@@ -11,6 +11,7 @@ import {
     matchSteps,
 } from './validation/step-definition-validation';
 import { applyTagFilters } from './tag-filtering';
+import { globalSteps } from './global-steps';
 
 export type StepsDefinitionCallbackOptions = {
     defineStep: DefineStepFunction;
@@ -246,12 +247,12 @@ const createDefineScenarioFunctionWithAliases = (
     return defineScenarioFunctionWithAliases as DefineScenarioFunctionWithAliases;
 };
 
-const createDefineStepFunction = (scenarioFromStepDefinitions: ScenarioFromStepDefinitions) => {
-    return (stepMatcher: string | RegExp, stepFunction: () => any) => {
-        const stepDefinition: StepFromStepDefinitions = {
+export const createDefineStepFunction = (scenarioFromStepDefinitions: ScenarioFromStepDefinitions) => {
+    return (stepMatcher: string | RegExp, stepFunction?: () => any) => {
+        const stepDefinition: StepFromStepDefinitions = stepFunction ? {
             stepMatcher,
             stepFunction,
-        };
+        } : globalSteps.get(stepMatcher)!;
 
         scenarioFromStepDefinitions.steps.push(stepDefinition);
     };
@@ -270,7 +271,7 @@ export function defineFeature(
 
     if (
         parsedFeatureWithTagFiltersApplied.scenarios.length === 0
-            && parsedFeatureWithTagFiltersApplied.scenarioOutlines.length === 0
+        && parsedFeatureWithTagFiltersApplied.scenarioOutlines.length === 0
     ) {
         return;
     }

--- a/src/feature-definition-creation.ts
+++ b/src/feature-definition-creation.ts
@@ -247,7 +247,7 @@ const createDefineScenarioFunctionWithAliases = (
     return defineScenarioFunctionWithAliases as DefineScenarioFunctionWithAliases;
 };
 
-export const createDefineStepFunction = (scenarioFromStepDefinitions: ScenarioFromStepDefinitions) => {
+const createDefineStepFunction = (scenarioFromStepDefinitions: ScenarioFromStepDefinitions) => {
     return (stepMatcher: string | RegExp, stepFunction?: () => any) => {
         const stepDefinition: StepFromStepDefinitions = {
             stepMatcher,

--- a/src/feature-definition-creation.ts
+++ b/src/feature-definition-creation.ts
@@ -249,11 +249,10 @@ const createDefineScenarioFunctionWithAliases = (
 
 export const createDefineStepFunction = (scenarioFromStepDefinitions: ScenarioFromStepDefinitions) => {
     return (stepMatcher: string | RegExp, stepFunction?: () => any) => {
-        const stepDefinition: StepFromStepDefinitions = stepFunction ? {
+        const stepDefinition: StepFromStepDefinitions = {
             stepMatcher,
-            stepFunction,
-        } : globalSteps.get(stepMatcher)!;
-
+            stepFunction: stepFunction || globalSteps.get(stepMatcher as string),
+        };
         scenarioFromStepDefinitions.steps.push(stepDefinition);
     };
 };

--- a/src/global-steps.ts
+++ b/src/global-steps.ts
@@ -1,5 +1,3 @@
-import { isRegExp, isString } from 'util';
-
 interface GlobalStep {
     stepMatcher: string | RegExp;
     stepFunction: () => any;
@@ -11,22 +9,36 @@ class Steps {
     push(step: GlobalStep) {
         const { stepMatcher } = step;
 
-        if (this.get(stepMatcher)) {
+        const isAlreadyAdded = this.list.some(
+            step => String(step.stepMatcher) === String(stepMatcher),
+        );
+
+        if (isAlreadyAdded) {
             throw new Error(`Existing global step with the name ${stepMatcher}`);
         }
 
         this.list.push(step);
     }
 
-    get(input: GlobalStep["stepMatcher"]) {
-        return this.list.find(item => {
-            if (isRegExp(item.stepMatcher)) {
-                return item.stepMatcher === input;
+    get(title: string) {
+        let params;
+
+        const found = this.list.find((step) => {
+            const matches = title.match(step.stepMatcher);
+
+            if (matches) {
+                params = matches.slice(1);
+                return true;
             }
-            if (isString(item.stepMatcher)) {
-                return item.stepMatcher.match(input);
-            }
+
+            return false;
         });
+
+        if (!found) {
+            throw Error(`${title} : was not defined in Steps file`);
+        }
+
+        return found.stepFunction.bind(this, ...params);
     }
 }
 

--- a/src/global-steps.ts
+++ b/src/global-steps.ts
@@ -1,12 +1,9 @@
-interface GlobalStep {
-    stepMatcher: string | RegExp;
-    stepFunction: () => any;
-}
+import { StepFromStepDefinitions } from './models';
 
 class Steps {
-    list: GlobalStep[] = [];
+    list: StepFromStepDefinitions[] = [];
 
-    push(step: GlobalStep) {
+    push(step: StepFromStepDefinitions) {
         const { stepMatcher } = step;
 
         const isAlreadyAdded = this.list.some(
@@ -20,15 +17,21 @@ class Steps {
         this.list.push(step);
     }
 
-    get(title: string) {
+    get(title: StepFromStepDefinitions["stepMatcher"]) {
         let params;
 
         const found = this.list.find((step) => {
-            const matches = title.match(step.stepMatcher);
+            if (typeof title === 'string') {
+                const matches = title.match(step.stepMatcher);
 
-            if (matches) {
-                params = matches.slice(1);
-                return true;
+                if (matches) {
+                    params = matches.slice(1);
+                    return true;
+                }
+            }
+
+            if (title instanceof RegExp) {
+                return String(title) === String(step.stepMatcher);
             }
 
             return false;
@@ -44,6 +47,9 @@ class Steps {
 
 export const globalSteps = new Steps();
 
-export function defineGlobalStep(stepMatcher: string | RegExp, stepFunction: () => any) {
+export function defineGlobalStep(
+    stepMatcher: StepFromStepDefinitions["stepMatcher"],
+    stepFunction: StepFromStepDefinitions["stepFunction"]
+) {
     globalSteps.push({ stepMatcher, stepFunction });
 }

--- a/src/global-steps.ts
+++ b/src/global-steps.ts
@@ -1,0 +1,37 @@
+import { isRegExp, isString } from 'util';
+
+interface GlobalStep {
+    stepMatcher: string | RegExp;
+    stepFunction: () => any;
+}
+
+class Steps {
+    list: GlobalStep[] = [];
+
+    push(step: GlobalStep) {
+        const { stepMatcher } = step;
+
+        if (this.get(stepMatcher)) {
+            throw new Error(`Existing global step with the name ${stepMatcher}`);
+        }
+
+        this.list.push(step);
+    }
+
+    get(input: GlobalStep["stepMatcher"]) {
+        return this.list.find(item => {
+            if (isRegExp(item.stepMatcher)) {
+                return item.stepMatcher === input;
+            }
+            if (isString(item.stepMatcher)) {
+                return item.stepMatcher.match(input);
+            }
+        });
+    }
+}
+
+export const globalSteps = new Steps();
+
+export function defineGlobalStep(stepMatcher: string | RegExp, stepFunction: () => any) {
+    globalSteps.push({ stepMatcher, stepFunction });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export {
   generateCodeFromFeature,
   generateCodeWithSeparateFunctionsFromFeature,
 } from './code-generation/generate-code-by-line-number';
+export { defineGlobalStep } from './global-steps';

--- a/src/models.ts
+++ b/src/models.ts
@@ -61,6 +61,7 @@ export type ErrorOptions = {
 
 export type Options = {
     loadRelativePath?: boolean;
+    disableRegexGeneration?: boolean;
     tagFilter?: string;
     errors?: ErrorOptions | boolean;
     scenarioNameTemplate?: (vars: ScenarioNameTemplateVars) => string;


### PR DESCRIPTION
Implements a function which allows the user to define global steps.

The system searches for a global match if there is no step defined (ie. `when('I click the button')` as opposed to `when('I click the button', () => {...})`). When this happens, we search through the available global steps; if no match exists, it will throw an error.

In addition, code generation should search through the global steps and automatically remove the function callback where there is an existing global step with the same name.

Lastly, I added an opt-in option to disable code generation from giving you regexes -- this is because the regex match for globals is quite precarious (it needs to be a === string match), and because with global steps, you may actually want all of your steps to be strings and to throw on any change. You probably won't need it for most cases, but it's good to have.

Thanks to @pedrowilkens for the idea -- this is effectively his code with a few adjustments:
https://github.com/bencompton/jest-cucumber/issues/52#issuecomment-466770413