### PR TITLE
Scenario outline title fix

### DIFF
--- a/examples/ecmascript/package.json
+++ b/examples/ecmascript/package.json
@@ -4,7 +4,8 @@
   "description": "Execute Gherkin scenarios in Jest",
   "main": "dist/src/index.js",
   "scripts": {
-    "test": "jest --color"
+    "test": "jest --color",
+    "jest": "jest --verbose"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/examples/ecmascript/specs/features/scenario-outlines.feature
+++ b/examples/ecmascript/specs/features/scenario-outlines.feature
@@ -1,6 +1,6 @@
 Feature: Online sales
 
-Scenario Outline: Selling an item at $<Amount>
+Scenario Outline: Selling an <Item> at $<Amount>
     Given I have a(n) <Item>
     When I sell the <Item>
     Then I should get $<Amount>


### PR DESCRIPTION
When using the ECMAScript found that when the update for table <title> was added this section didn't match the step_definitions with feature file. Also, add a simple `jest -verbose` script to the package. 