### PR TITLE
Support for docstrings in scenario outlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Scenario: Launching a SpaceX rocket
 
 ### Add the following to your Jest configuration:
 
-```javascript  
+```javascript
   "testMatch": [
     "**/*.steps.js"
   ],
@@ -59,7 +59,7 @@ const feature = loadFeature('./features/RocketLaunching.feature');
 ```javascript
 //rocket-launching.steps.js
 
-    import { defineFeature, loadFeature } from 'jest-cucumber';
+import { defineFeature, loadFeature } from 'jest-cucumber';
 
 const feature = loadFeature('./features/RocketLaunching.feature');
 
@@ -111,6 +111,7 @@ defineFeature(feature, test => {
   * [Gherkin tables](./docs/GherkinTables.md)
   * [Step definition arguments](./docs/StepDefinitionArguments.md)
   * [Scenario outlines](./docs/ScenarioOutlines.md)
-  * [Re-using step definitions](./docs/ReusingStepDefinitions.md)  
+  * [Re-using step definitions](./docs/ReusingStepDefinitions.md)
   * [Configuration options](./docs/AdditionalConfiguration.md)
   * [Running the examples](./docs/RunningTheExamples.md)
+  * [Using Docstrings](./docs/UsingDocstrings.md)

--- a/docs/ScenarioOutlines.md
+++ b/docs/ScenarioOutlines.md
@@ -1,5 +1,9 @@
 # Scenario outlines
 
+Jest Cucumber allows you to create scenario outlines by adding placeholders to your steps and titles. Placeholders are written as `<PLACEHOLDER>` where `PLACEHOLDER` is a reference to a column heading in the `Examples:` table. Jest Cucumber will run the scenario once for each row in the `Examples:` table, replacing the placeholder with the value of the referenced column of the current row.
+
+Placeholders are allowed in the scenario's title, its steps, gherkin tables and docstrings.
+
 ```gherkin
 Feature: Online sales
 
@@ -25,7 +29,7 @@ const feature = loadFeature('./features/OnlineSales.feature');
 defineFeature(feature, test => {
   let onlineSales;
   let salesPrice;
-		
+
   beforeEach(() => {
     onlineSales = new OnlineSales();
   });

--- a/docs/UsingDocstrings.md
+++ b/docs/UsingDocstrings.md
@@ -1,0 +1,55 @@
+# Using Docstrings
+
+```gherkin
+Feature: Certificate manufacturing
+
+Scenario Outline: Print a certificate
+  Given <Title> <LastName> has achieved a <Score>
+  When I print the certificate
+  Then It prints
+    """
+    Certificate of Mastery
+    The title of <Rank> is hereby awarded to:
+    <Title> <LastName>
+    For achieving a score of <Score>, <Title> <LastName>
+    may henceforth use the title <Rank>.
+    """
+
+  Examples:
+
+  | Title | LastName  | Score | Rank              |
+  | Mr.   | Vega      | 1000  | Novice            |
+  | Mrs.  | Wallace   | 2001  | Expert            |
+  | Mr.   | Winnfield | 2550  | Grandmaster       |
+  | Ms.   | Bunny     | 2800  | Super Grandmaster |
+```
+
+```javascript
+import { defineFeature, loadFeature } from "jest-cucumber";
+import { CertificateFactory } from "../../src/certificate-factory";
+
+const feature = loadFeature("./specs/features/using-docstrings.feature");
+
+defineFeature(feature, test => {
+  let certificateFactory;
+  let certificate;
+
+  beforeEach(() => {
+    certificateFactory = new CertificateFactory();
+  });
+
+  test("Print a certificate", ({ given, when, then }) => {
+    given(/^(.*) (.*) has achieved a ([0-9]*)$/, (title, lastName, score) => {
+      certificateFactory.setReceiver(title, lastName, score);
+    });
+
+    when(/^I print the certificate$/, () => {
+      certificate = certificateFactory.printCertificate();
+    });
+
+    then(/^It prints$/, expectedCertificate => {
+      expect(certificate).toBe(expectedCertificate);
+    });
+  });
+});
+```

--- a/examples/ecmascript/specs/features/more-scenario-outlines.feature
+++ b/examples/ecmascript/specs/features/more-scenario-outlines.feature
@@ -1,0 +1,26 @@
+Feature: Series Solver
+
+Scenario Outline: Solving series
+    Given I have a series <First> <Operator> <Second> <Operator> <Third> <Operator> ...
+    When I solve the series
+    Then I should get <Solution> as the answer
+
+    Examples:
+
+      | First | Second | Third | Operator | Solution |
+      | 1     | 2      | 3     | +        | -1/12    |
+      | 1     | 1/2    | 1/4   | +        | 2        |
+      | 1/0!  | 1/1!   | 1/2!  | +        | e        |
+
+Scenario Outline: Adding series
+    Given I add the following series:
+      | Series                                                        | Operator   | Solution   |
+      | <First> <Operator> <Second> <Operator> <Third> <Operator> ... | <Operator> | <Solution> |
+    When I solve the series
+    Then I should get <Solution> as the answer
+
+    Examples:
+      | First     | Second    | Third     | Operator | Solution |
+      | 3/10      | 3/100     | 3/1000    | +        | 1/3      |
+      | 1+3^(2*0) | 1+3^(2*1) | 1+3^(2*2) | *        | -1/2     |
+      | 1/2       | 1/4       | 1/8       | +        | 1        |

--- a/examples/ecmascript/specs/features/using-docstrings.feature
+++ b/examples/ecmascript/specs/features/using-docstrings.feature
@@ -1,0 +1,21 @@
+Feature: Certificate manufaturing
+
+Scenario Outline: Print a certificate
+    Given <Titel> <LastName> has achieved a <Score>
+    When I print the certificate
+    Then It prints
+        """
+        Certificate of Mastery
+        The title of <Rank> is hereby awarded to:
+        <Title> <LastName>
+        For achieving a score of <Score>
+        """
+
+    Examples:
+
+        | Title | LastName  | Score | Rank              |
+        | Mr.   | Vega      | 1000  | Novice            |
+        | Mrs.  | Wallace   | 2001  | Expert            |
+        | Mr.   | Winnfield | 2550  | Grandmaster       |
+        | Ms.   | Bunny     | 2800  | Super Grandmaster |
+

--- a/examples/ecmascript/specs/features/using-docstrings.feature
+++ b/examples/ecmascript/specs/features/using-docstrings.feature
@@ -1,7 +1,7 @@
 Feature: Certificate manufaturing
 
 Scenario Outline: Print a certificate
-    Given <Titel> <LastName> has achieved a <Score>
+    Given <Title> <LastName> has achieved a <Score>
     When I print the certificate
     Then It prints
         """

--- a/examples/ecmascript/specs/features/using-docstrings.feature
+++ b/examples/ecmascript/specs/features/using-docstrings.feature
@@ -1,4 +1,4 @@
-Feature: Certificate manufaturing
+Feature: Certificate manufacturing
 
 Scenario Outline: Print a certificate
     Given <Title> <LastName> has achieved a <Score>
@@ -8,7 +8,8 @@ Scenario Outline: Print a certificate
         Certificate of Mastery
         The title of <Rank> is hereby awarded to:
         <Title> <LastName>
-        For achieving a score of <Score>
+        For achieving a score of <Score>, <Title> <LastName>
+        may henceforth use the title <Rank>.
         """
 
     Examples:

--- a/examples/ecmascript/specs/step-definitions/more-scenario-outlines.steps.js
+++ b/examples/ecmascript/specs/step-definitions/more-scenario-outlines.steps.js
@@ -1,0 +1,58 @@
+import { defineFeature, loadFeature } from 'jest-cucumber';
+import { SeriesSolver } from '../../src/series-solver';
+
+const feature = loadFeature('./specs/features/more-scenario-outlines.feature');
+
+defineFeature(feature, (test) => {
+  let solver;
+  let solution;
+  let terms;
+  let operator;
+
+  beforeEach(() => {
+    solver = new SeriesSolver();
+  });
+
+  const whenISolveTheSeries = (when) => {
+    when(/^I solve the series$/, () => {
+      solution = solver.solve(terms, operator);
+    });
+  };
+
+  const thenIShouldGetXAsTheAnswer = (then) => {
+    then(/^I should get (.*) as the answer$/, (expectedSolution) => {
+      expect(solution).toBe(expectedSolution);
+    });
+  };
+
+  test('Solving series', ({ given, when, then }) => {
+    given(
+      /^I have a series (.*) (.*) (.*) (.*) (.*) (.*) (.*)$/,
+      (firstTerm, firstOperator, secondTerm, secondOperator, thirdTerm, thirdOperator, forthTerm) => {
+        expect(firstOperator).toEqual(secondOperator);
+        expect(firstOperator).toEqual(thirdOperator);
+
+        operator = firstOperator;
+        terms = [firstTerm, secondTerm, thirdTerm, forthTerm];
+      });
+
+    whenISolveTheSeries(when);
+
+    thenIShouldGetXAsTheAnswer(then);
+  });
+
+  test('Adding series', ({ given, when, then }) => {
+    given(
+      /^I add the following series:$/,
+      (table) => {
+        const row = table[0];
+        terms = row.Series.split(` ${row.Operator} `);
+        operator = row.Operator;
+        solver.add(terms, operator, row.Solution);
+      });
+
+    whenISolveTheSeries(when);
+
+    thenIShouldGetXAsTheAnswer(then);
+  });
+});

--- a/examples/ecmascript/specs/step-definitions/using-docstrings.steps.js
+++ b/examples/ecmascript/specs/step-definitions/using-docstrings.steps.js
@@ -1,0 +1,27 @@
+import { defineFeature, loadFeature } from 'jest-cucumber';
+import { CertificateFactory } from '../../src/certificate-factory';
+
+const feature = loadFeature('./specs/features/using-docstrings.feature');
+
+defineFeature(feature, test => {
+    let certificateFactory;
+    let certificate;
+
+    beforeEach(() => {
+        certificateFactory = new CertificateFactory();
+    });
+
+    test('Print a certificate', ({ given, when, then }) => {
+        given(/^(.*) (.*) has achieved a ([0-9]*)$/, (title, lastName, score) => {
+            certificateFactory.setReceiver(title, lastName, score);
+        });
+
+        when(/^I print the certificate$/, () => {
+            certificate = certificateFactory.printCertificate();
+        });
+
+        then(/^It prints$/, (expectedCertificate) => {
+            expect(certificate).toBe(expectedCertificate);
+        });
+    });
+});

--- a/examples/ecmascript/src/certificate-factory.js
+++ b/examples/ecmascript/src/certificate-factory.js
@@ -21,10 +21,11 @@ export class CertificateFactory {
 
     printCertificate() {
         const pieces = [
-            `Certificate of ${this.rank}`,
+            `Certificate of Mastery`,
             `The title of ${this.rank} is hereby awarded to:`,
             `${this.title} ${this.lastName}`,
-            `For achieving a score of ${this.score}`,
+            `For achieving a score of ${this.score}, ${this.title} ${this.lastName}`,
+            `may henceforth use the title ${this.rank}.`,
         ];
 
         return pieces.join('\n');

--- a/examples/ecmascript/src/certificate-factory.js
+++ b/examples/ecmascript/src/certificate-factory.js
@@ -27,6 +27,6 @@ export class CertificateFactory {
             `For achieving a score of ${this.score}`,
         ];
 
-        return pieces.join('\n').trim();
+        return pieces.join('\n');
     }
 }

--- a/examples/ecmascript/src/certificate-factory.js
+++ b/examples/ecmascript/src/certificate-factory.js
@@ -1,0 +1,32 @@
+export class CertificateFactory {
+    constructor() {
+        this.title = '';
+        this.lastName = '';
+        this.score = 0;
+        this.rank = 'Novice';
+    }
+
+    setReceiver(title, name, score) {
+        this.title = title;
+        this.lastName = name;
+        this.score = Number.parseInt(score, 10);
+        if (this.score > 2700) {
+            this.rank = 'Super Grandmaster';
+        } else if (this.score > 2500) {
+            this.rank = 'Grandmaster';
+        } else if (this.score > 2000) {
+            this.rank = 'Expert';
+        }
+    }
+
+    printCertificate() {
+        const pieces = [
+            'Certificate of Mastery',
+            `The title of ${this.rank} is hereby awarded to:`,
+            `${this.title} ${this.lastName}`,
+            `For achieving a score of ${this.score}`,
+        ];
+
+        return pieces.join('\n').trim();
+    }
+}

--- a/examples/ecmascript/src/certificate-factory.js
+++ b/examples/ecmascript/src/certificate-factory.js
@@ -21,7 +21,7 @@ export class CertificateFactory {
 
     printCertificate() {
         const pieces = [
-            'Certificate of Mastery',
+            `Certificate of ${this.rank}`,
             `The title of ${this.rank} is hereby awarded to:`,
             `${this.title} ${this.lastName}`,
             `For achieving a score of ${this.score}`,

--- a/examples/ecmascript/src/series-solver.js
+++ b/examples/ecmascript/src/series-solver.js
@@ -1,0 +1,19 @@
+export class SeriesSolver {
+  constructor() {
+    this.solutions = {
+      '1+2+3+...': '-1/12',
+      '1/0!+1/1!+1/2!+...': 'e',
+      '1+1/2+1/4+...': '2',
+    };
+  }
+
+  solve(terms, operator) {
+    const series = terms.join(operator);
+    return this.solutions[series];
+  }
+
+  add(terms, operator, solution) {
+    const series = terms.join(operator);
+    this.solutions[series] = solution;
+  }
+}

--- a/examples/typescript/specs/features/more-scenario-outlines.feature
+++ b/examples/typescript/specs/features/more-scenario-outlines.feature
@@ -11,3 +11,16 @@ Scenario Outline: Solving series
       | 1     | 2      | 3     | +        | -1/12    |
       | 1     | 1/2    | 1/4   | +        | 2        |
       | 1/0!  | 1/1!   | 1/2!  | +        | e        |
+
+Scenario Outline: Adding series
+    Given I add the following series:
+      | Series                                                        | Operator   | Solution   |
+      | <First> <Operator> <Second> <Operator> <Third> <Operator> ... | <Operator> | <Solution> |
+    When I solve the series
+    Then I should get <Solution> as the answer
+
+    Examples:
+      | First     | Second    | Third     | Operator | Solution |
+      | 3/10      | 3/100     | 3/1000    | +        | 1/3      |
+      | 1+3^(2*0) | 1+3^(2*1) | 1+3^(2*2) | *        | -1/2     |
+      | 1/2       | 1/4       | 1/8       | +        | 1        |

--- a/examples/typescript/specs/features/more-scenario-outlines.feature
+++ b/examples/typescript/specs/features/more-scenario-outlines.feature
@@ -1,0 +1,13 @@
+Feature: Series Solver
+
+Scenario Outline: Solving series
+    Given I have a series <First> <Operator> <Second> <Operator> <Third> <Operator> ...
+    When I solve the series
+    Then I should get <Solution> as the answer
+
+    Examples:
+
+      | First | Second | Third | Operator | Solution |
+      | 1     | 2      | 3     | +        | -1/12    |
+      | 1     | 1/2    | 1/4   | +        | 2        |
+      | 1/0!  | 1/1!   | 1/2!  | +        | e        |

--- a/examples/typescript/specs/features/using-docstrings.feature
+++ b/examples/typescript/specs/features/using-docstrings.feature
@@ -1,0 +1,21 @@
+Feature: Certificate manufaturing
+
+Scenario Outline: Print a certificate
+    Given <Titel> <LastName> has achieved a <Score>
+    When I print the certificate
+    Then It prints
+        """
+        Certificate of Mastery
+        The title of <Rank> is hereby awarded to:
+        <Title> <LastName>
+        For achieving a score of <Score>
+        """
+
+    Examples:
+
+        | Title | LastName  | Score | Rank              |
+        | Mr.   | Vega      | 1000  | Novice            |
+        | Mrs.  | Wallace   | 2001  | Expert            |
+        | Mr.   | Winnfield | 2550  | Grandmaster       |
+        | Ms.   | Bunny     | 2800  | Super Grandmaster |
+

--- a/examples/typescript/specs/features/using-docstrings.feature
+++ b/examples/typescript/specs/features/using-docstrings.feature
@@ -1,7 +1,7 @@
 Feature: Certificate manufaturing
 
 Scenario Outline: Print a certificate
-    Given <Titel> <LastName> has achieved a <Score>
+    Given <Title> <LastName> has achieved a <Score>
     When I print the certificate
     Then It prints
         """

--- a/examples/typescript/specs/features/using-docstrings.feature
+++ b/examples/typescript/specs/features/using-docstrings.feature
@@ -1,4 +1,4 @@
-Feature: Certificate manufaturing
+Feature: Certificate manufacturing
 
 Scenario Outline: Print a certificate
     Given <Title> <LastName> has achieved a <Score>
@@ -8,7 +8,8 @@ Scenario Outline: Print a certificate
         Certificate of Mastery
         The title of <Rank> is hereby awarded to:
         <Title> <LastName>
-        For achieving a score of <Score>
+        For achieving a score of <Score>, <Title> <LastName>
+        may henceforth use the title <Rank>.
         """
 
     Examples:

--- a/examples/typescript/specs/step-definitions/more-scenario-outlines.steps.ts
+++ b/examples/typescript/specs/step-definitions/more-scenario-outlines.steps.ts
@@ -1,4 +1,4 @@
-import { defineFeature, loadFeature } from '../../../../src';
+import { defineFeature, loadFeature, DefineStepFunction } from '../../../../src';
 import { SeriesSolver } from '../../src/series-solver';
 
 const feature = loadFeature('./examples/typescript/specs/features/more-scenario-outlines.feature');
@@ -13,6 +13,18 @@ defineFeature(feature, (test) => {
     solver = new SeriesSolver();
   });
 
+  const whenISolveTheSeries = (when: DefineStepFunction) => {
+    when(/^I solve the series$/, () => {
+      solution = solver.solve(terms, operator);
+    });
+  };
+
+  const thenIShouldGetXAsTheAnswer = (then: DefineStepFunction) => {
+    then(/^I should get (.*) as the answer$/, (expectedSolution) => {
+      expect(solution).toBe(expectedSolution);
+    });
+  };
+
   test('Solving series', ({ given, when, then }) => {
     given(
       /^I have a series (.*) (.*) (.*) (.*) (.*) (.*) \.\.\.$/,
@@ -24,12 +36,23 @@ defineFeature(feature, (test) => {
         terms = [firstTerm, secondTerm, thirdTerm];
       });
 
-    when(/^I solve the series$/, () => {
-      solution = solver.solve(terms, operator);
-    });
+    whenISolveTheSeries(when);
 
-    then(/^I should get (.*) as the answer$/, (expectedSolution) => {
-      expect(solution).toBe(expectedSolution);
-    });
+    thenIShouldGetXAsTheAnswer(then);
+  });
+
+  test('Adding series', ({ given, when, then }) => {
+    given(
+      /^I add the following series:$/,
+      (table: [{ Series: string, Operator: string, Solution: string }]) => {
+        const row = table[0];
+        terms = row.Series.split(` ${row.Operator} `);
+        operator = row.Operator;
+        solver.add(terms, operator, row.Solution);
+      });
+
+    whenISolveTheSeries(when);
+
+    thenIShouldGetXAsTheAnswer(then);
   });
 });

--- a/examples/typescript/specs/step-definitions/more-scenario-outlines.steps.ts
+++ b/examples/typescript/specs/step-definitions/more-scenario-outlines.steps.ts
@@ -1,0 +1,35 @@
+import { defineFeature, loadFeature } from '../../../../src';
+import { SeriesSolver } from '../../src/series-solver';
+
+const feature = loadFeature('./examples/typescript/specs/features/more-scenario-outlines.feature');
+
+defineFeature(feature, (test) => {
+  let solver: SeriesSolver;
+  let solution: string;
+  let terms: string[];
+  let operator: string;
+
+  beforeEach(() => {
+    solver = new SeriesSolver();
+  });
+
+  test('Solving series', ({ given, when, then }) => {
+    given(
+      /^I have a series (.*) (.*) (.*) (.*) (.*) (.*) \.\.\.$/,
+      (firstTerm, firstOperator, secondTerm, secondOperator, thirdTerm, thirdOperator) => {
+        expect(firstOperator).toEqual(secondOperator);
+        expect(firstOperator).toEqual(thirdOperator);
+
+        operator = firstOperator;
+        terms = [firstTerm, secondTerm, thirdTerm];
+      });
+
+    when(/^I solve the series$/, () => {
+      solution = solver.solve(terms, operator);
+    });
+
+    then(/^I should get (.*) as the answer$/, (expectedSolution) => {
+      expect(solution).toBe(expectedSolution);
+    });
+  });
+});

--- a/examples/typescript/specs/step-definitions/more-scenario-outlines.steps.ts
+++ b/examples/typescript/specs/step-definitions/more-scenario-outlines.steps.ts
@@ -27,13 +27,13 @@ defineFeature(feature, (test) => {
 
   test('Solving series', ({ given, when, then }) => {
     given(
-      /^I have a series (.*) (.*) (.*) (.*) (.*) (.*) \.\.\.$/,
-      (firstTerm, firstOperator, secondTerm, secondOperator, thirdTerm, thirdOperator) => {
+      /^I have a series (.*) (.*) (.*) (.*) (.*) (.*) (.*)$/,
+      (firstTerm, firstOperator, secondTerm, secondOperator, thirdTerm, thirdOperator, forthTerm) => {
         expect(firstOperator).toEqual(secondOperator);
         expect(firstOperator).toEqual(thirdOperator);
 
         operator = firstOperator;
-        terms = [firstTerm, secondTerm, thirdTerm];
+        terms = [firstTerm, secondTerm, thirdTerm, forthTerm];
       });
 
     whenISolveTheSeries(when);

--- a/examples/typescript/specs/step-definitions/using-docstrings.steps.ts
+++ b/examples/typescript/specs/step-definitions/using-docstrings.steps.ts
@@ -1,0 +1,27 @@
+import { defineFeature, loadFeature } from '../../../../src/';
+import { CertificateFactory } from '../../src/certificate-factory';
+
+const feature = loadFeature('./examples/typescript/specs/features/using-docstrings.feature');
+
+defineFeature(feature, (test) => {
+    let certificateFactory: CertificateFactory;
+    let certificate: string | null;
+
+    beforeEach(() => {
+        certificateFactory = new CertificateFactory();
+    });
+
+    test('Print a certificate', ({ given, when, then }) => {
+        given(/^(.*) (.*) has achieved a ([0-9]*)$/, (title, lastName, score) => {
+            certificateFactory.setReceiver(title, lastName, score);
+        });
+
+        when(/^I print the certificate$/, () => {
+            certificate = certificateFactory.printCertificate();
+        });
+
+        then(/^It prints$/, (expectedCertificate) => {
+            expect(certificate).toBe(expectedCertificate);
+        });
+    });
+});

--- a/examples/typescript/src/certificate-factory.ts
+++ b/examples/typescript/src/certificate-factory.ts
@@ -25,6 +25,6 @@ export class CertificateFactory {
             `For achieving a score of ${this.score}`,
         ];
 
-        return pieces.join('\n').trim();
+        return pieces.join('\n');
     }
 }

--- a/examples/typescript/src/certificate-factory.ts
+++ b/examples/typescript/src/certificate-factory.ts
@@ -1,0 +1,30 @@
+export class CertificateFactory {
+    private title = '';
+    private lastName = '';
+    private score = 0;
+    private rank = 'Novice';
+
+    public setReceiver(title: string, name: string, score: string) {
+        this.title = title;
+        this.lastName = name;
+        this.score = Number.parseInt(score, 10);
+        if (this.score > 2700) {
+            this.rank = 'Super Grandmaster';
+        } else if (this.score > 2500) {
+            this.rank = 'Grandmaster';
+        } else if (this.score > 2000) {
+            this.rank = 'Expert';
+        }
+    }
+
+    public printCertificate() {
+        const pieces = [
+            'Certificate of Mastery',
+            `The title of ${this.rank} is hereby awarded to:`,
+            `${this.title} ${this.lastName}`,
+            `For achieving a score of ${this.score}`,
+        ];
+
+        return pieces.join('\n').trim();
+    }
+}

--- a/examples/typescript/src/certificate-factory.ts
+++ b/examples/typescript/src/certificate-factory.ts
@@ -19,10 +19,11 @@ export class CertificateFactory {
 
     public printCertificate() {
         const pieces = [
-            'Certificate of Mastery',
+            `Certificate of Mastery`,
             `The title of ${this.rank} is hereby awarded to:`,
             `${this.title} ${this.lastName}`,
-            `For achieving a score of ${this.score}`,
+            `For achieving a score of ${this.score}, ${this.title} ${this.lastName}`,
+            `may henceforth use the title ${this.rank}.`,
         ];
 
         return pieces.join('\n');

--- a/examples/typescript/src/series-solver.ts
+++ b/examples/typescript/src/series-solver.ts
@@ -9,4 +9,9 @@ export class SeriesSolver {
     const series = terms.join(operator);
     return this.solutions[series];
   }
+
+  public add(terms: string[], operator: string, solution: string) {
+    const series = terms.join(operator);
+    this.solutions[series] = solution;
+  }
 }

--- a/examples/typescript/src/series-solver.ts
+++ b/examples/typescript/src/series-solver.ts
@@ -2,7 +2,7 @@ export class SeriesSolver {
   private solutions: { [key: string]: string } = {
     '1+2+3+...': '-1/12',
     '1/0!+1/1!+1/2!+...': 'e',
-    '1/1+1/2+1/4+...': '2',
+    '1+1/2+1/4+...': '2',
   };
 
   public solve(terms: string[], operator: string) {

--- a/examples/typescript/src/series-solver.ts
+++ b/examples/typescript/src/series-solver.ts
@@ -1,0 +1,12 @@
+export class SeriesSolver {
+  private solutions: { [key: string]: string } = {
+    '1+2+3+...': '-1/12',
+    '1/0!+1/1!+1/2!+...': 'e',
+    '1/1+1/2+1/4+...': '2',
+  };
+
+  public solve(terms: string[], operator: string) {
+    const series = terms.join(operator);
+    return this.solutions[series];
+  }
+}

--- a/src/parsed-feature-loading.ts
+++ b/src/parsed-feature-loading.ts
@@ -87,7 +87,7 @@ const parseScenario = (astScenario: any) => {
 const parseScenarioOutlineExampleSteps = (exampleTableRow: any, scenarioSteps: ParsedStep[]) => {
     return scenarioSteps.map((scenarioStep) => {
         const stepText = Object.keys(exampleTableRow).reduce((processedStepText, nextTableColumn) => {
-            return processedStepText.replace(`<${nextTableColumn}>`, exampleTableRow[nextTableColumn]);
+            return processedStepText.replace(new RegExp(`<${nextTableColumn}>`, 'g'), exampleTableRow[nextTableColumn]);
         }, scenarioStep.stepText);
 
         let stepArgument: string | {} = '';
@@ -101,7 +101,7 @@ const parseScenarioOutlineExampleSteps = (exampleTableRow: any, scenarioSteps: P
                         Object.keys(modifiedStepArgumentRow).forEach((prop) => {
                             modifiedStepArgumentRow[prop] =
                                 modifiedStepArgumentRow[prop].replace(
-                                    `<${nextTableColumn}>`,
+                                    new RegExp(`<${nextTableColumn}>`, 'g'),
                                     exampleTableRow[nextTableColumn],
                                 );
                         });
@@ -118,7 +118,7 @@ const parseScenarioOutlineExampleSteps = (exampleTableRow: any, scenarioSteps: P
                 ) {
                     Object.keys(exampleTableRow).forEach((nextTableColumn) => {
                         stepArgument = (stepArgument as string).replace(
-                            `<${nextTableColumn}>`,
+                            new RegExp(`<${nextTableColumn}>`, 'g'),
                             exampleTableRow[nextTableColumn],
                         );
                     });

--- a/src/parsed-feature-loading.ts
+++ b/src/parsed-feature-loading.ts
@@ -90,24 +90,40 @@ const parseScenarioOutlineExampleSteps = (exampleTableRow: any, scenarioSteps: P
             return processedStepText.replace(`<${nextTableColumn}>`, exampleTableRow[nextTableColumn]);
         }, scenarioStep.stepText);
 
-        let stepArgument;
+        let stepArgument: string | {} = '';
 
         if (scenarioStep.stepArgument) {
-            stepArgument = (scenarioStep.stepArgument as any).map((stepArgumentRow: any) => {
-                const modifiedStepAgrumentRow = {...stepArgumentRow};
+            if (Array.isArray(scenarioStep.stepArgument)) {
+                stepArgument = (scenarioStep.stepArgument as any).map((stepArgumentRow: any) => {
+                    const modifiedStepArgumentRow = { ...stepArgumentRow };
 
-                Object.keys(exampleTableRow).forEach((nextTableColumn) => {
-                    Object.keys(modifiedStepAgrumentRow).forEach((prop) => {
-                        modifiedStepAgrumentRow[prop] =
-                            modifiedStepAgrumentRow[prop].replace(
-                                `<${nextTableColumn}>`,
-                                exampleTableRow[nextTableColumn],
-                            );
+                    Object.keys(exampleTableRow).forEach((nextTableColumn) => {
+                        Object.keys(modifiedStepArgumentRow).forEach((prop) => {
+                            modifiedStepArgumentRow[prop] =
+                                modifiedStepArgumentRow[prop].replace(
+                                    `<${nextTableColumn}>`,
+                                    exampleTableRow[nextTableColumn],
+                                );
+                        });
                     });
-                });
 
-                return modifiedStepAgrumentRow;
-            });
+                    return modifiedStepArgumentRow;
+                });
+            } else {
+                stepArgument = scenarioStep.stepArgument;
+
+                if (
+                    typeof scenarioStep.stepArgument === 'string' ||
+                    scenarioStep.stepArgument instanceof String
+                ) {
+                    Object.keys(exampleTableRow).forEach((nextTableColumn) => {
+                        stepArgument = (stepArgument as string).replace(
+                            `<${nextTableColumn}>`,
+                            exampleTableRow[nextTableColumn],
+                        );
+                    });
+                }
+            }
         }
 
         return {


### PR DESCRIPTION
Figured I might as well just create the pull request, I can always squash the commits later.

I've added what I hope is a solution to using Docstrings with Scenario Outlines as described in #7 and #79. The implementation is concentrated to `src/parsed-feature-loading.ts` I also added a couple of examples for TypeScript and ECMAScript to illustrate the new functionality (it was previously not possible to use Docstrings and Scenario Outlines together).

Have a look and ping me if there are any concerns. 