### PR TITLE
Added timeout option to add more control over async operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1760,7 +1760,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1778,11 +1779,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1795,15 +1798,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1906,7 +1912,8 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1916,6 +1923,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1928,17 +1936,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1955,6 +1966,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2035,7 +2047,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2045,6 +2058,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2120,7 +2134,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2150,6 +2165,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2167,6 +2183,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2205,11 +2222,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/feature-definition-creation.ts
+++ b/src/feature-definition-creation.ts
@@ -114,7 +114,7 @@ const defineScenario = (
     only: boolean = false,
     skip: boolean = false,
     concurrent: boolean = false,
-    timeout: number,
+    timeout: number = TIMEOUT,
 ) => {
     const testFunction = getTestFunction(parsedScenario.skippedViaTagFilter, only, skip, concurrent);
 

--- a/src/feature-definition-creation.ts
+++ b/src/feature-definition-creation.ts
@@ -12,6 +12,8 @@ import {
 } from './validation/step-definition-validation';
 import { applyTagFilters } from './tag-filtering';
 
+const TIMEOUT = 5000;
+
 export type StepsDefinitionCallbackOptions = {
     defineStep: DefineStepFunction;
     given: DefineStepFunction;
@@ -27,6 +29,7 @@ export type ScenariosDefinitionCallbackFunction = (defineScenario: DefineScenari
 export type DefineScenarioFunction = (
     scenarioTitle: string,
     stepsDefinitionCallback: StepsDefinitionCallbackFunction,
+    timeout?: number,
 ) => void;
 
 export type DefineScenarioFunctionWithAliases = DefineScenarioFunction & {
@@ -111,6 +114,7 @@ const defineScenario = (
     only: boolean = false,
     skip: boolean = false,
     concurrent: boolean = false,
+    timeout: number,
 ) => {
     const testFunction = getTestFunction(parsedScenario.skippedViaTagFilter, only, skip, concurrent);
 
@@ -131,7 +135,7 @@ const defineScenario = (
 
             return promiseChain.then(() => nextStep.stepFunction(...args));
         }, Promise.resolve());
-    });
+    }, timeout);
 };
 
 const createDefineScenarioFunction = (
@@ -140,6 +144,7 @@ const createDefineScenarioFunction = (
     only: boolean = false,
     skip: boolean = false,
     concurrent: boolean = false,
+    timeout: number = TIMEOUT,
 ) => {
     const defineScenarioFunction: DefineScenarioFunction = (
         scenarioTitle: string,
@@ -198,6 +203,7 @@ const createDefineScenarioFunction = (
                 only,
                 skip,
                 concurrent,
+                timeout,
             );
         } else if (parsedScenarioOutline) {
             parsedScenarioOutline.scenarios.forEach((scenario) => {
@@ -208,6 +214,7 @@ const createDefineScenarioFunction = (
                     only,
                     skip,
                     concurrent,
+                    timeout,
                 );
             });
         }
@@ -219,6 +226,7 @@ const createDefineScenarioFunction = (
 const createDefineScenarioFunctionWithAliases = (
     featureFromStepDefinitions: FeatureFromStepDefinitions,
     parsedFeature: ParsedFeature,
+    timeout: number = TIMEOUT,
 ) => {
     const defineScenarioFunctionWithAliases = createDefineScenarioFunction(featureFromStepDefinitions, parsedFeature);
 
@@ -226,6 +234,9 @@ const createDefineScenarioFunctionWithAliases = (
         featureFromStepDefinitions,
         parsedFeature,
         true,
+        false,
+        false,
+        timeout,
     );
 
     (defineScenarioFunctionWithAliases as DefineScenarioFunctionWithAliases).skip = createDefineScenarioFunction(
@@ -233,6 +244,8 @@ const createDefineScenarioFunctionWithAliases = (
         parsedFeature,
         false,
         true,
+        false,
+        timeout,
     );
 
     (defineScenarioFunctionWithAliases as DefineScenarioFunctionWithAliases).concurrent = createDefineScenarioFunction(
@@ -241,6 +254,7 @@ const createDefineScenarioFunctionWithAliases = (
         false,
         false,
         true,
+        timeout,
     );
 
     return defineScenarioFunctionWithAliases as DefineScenarioFunctionWithAliases;


### PR DESCRIPTION
Some hours ago I opened [an issue](https://github.com/bencompton/jest-cucumber/issues/83), I decided to help with this.

The "test" function now optionally accept the timeout option to control async operations. The default value is `5000`

Example:
<img width="371" alt="Screen Shot 2020-03-08 at 7 49 19 AM" src="https://user-images.githubusercontent.com/2402579/76164117-d12dcf00-6111-11ea-9674-2f34adc63ca2.png">

**Tests**: npm scripts has been run without any error.

Hope this get merged.