### PR TITLE
Language support

### DIFF
--- a/examples/typescript/specs/features/language.feature
+++ b/examples/typescript/specs/features/language.feature
@@ -1,0 +1,28 @@
+# language: nl
+
+Functionaliteit: Inloggen
+
+    Achtergrond: Voor inloggen heb je inloggegevens nodig
+
+    Rule: Regel is niet vertaalt
+
+    Scenario: Invullen van een correct wachtwoord
+        Gegeven ik heb voorheen een wachtwoord aangemaakt
+        Als ik het correcte wachtwoord invoer
+        Dan krijg ik toegang
+
+    Abstract Scenario: Verkoop <Artikel> voor €<Bedrag>
+        Gegeven ik heb een <Artikel>
+        Als ik <Artikel> verkoop
+        Dan zou ik €<Bedrag> ontvangen
+
+        Voorbeelden: :
+
+            | Artikel                                        | Bedrag |
+            | Handtekening Neil deGrasse Tyson boek          | 100    |
+            | Rick Astley t-shirt                            | 22     |
+            | Een idee om ALLES te vervangen met blockchains | 0      |
+
+
+        # add all possibilities
+

--- a/examples/typescript/specs/features/language.feature
+++ b/examples/typescript/specs/features/language.feature
@@ -1,6 +1,6 @@
 # language: nl
 
-Functionaliteit: Inloggen
+Functionaliteit: Taal test
 
     Achtergrond: Voor inloggen heb je inloggegevens nodig
 
@@ -16,13 +16,27 @@ Functionaliteit: Inloggen
         Als ik <Artikel> verkoop
         Dan zou ik €<Bedrag> ontvangen
 
-        Voorbeelden: :
+        Voorbeelden:
 
             | Artikel                                        | Bedrag |
-            | Handtekening Neil deGrasse Tyson boek          | 100    |
+            | Autographed Neil deGrasse Tyson book           | 100    |
             | Rick Astley t-shirt                            | 22     |
-            | Een idee om ALLES te vervangen met blockchains | 0      |
+            | An idea to replace EVERYTHING with blockchains | 0      |
 
+    Scenario: Mijn salaris storten
+        Gegeven mijn account balans is €10
+        Wanneer ik €1000000 krijg betaald voor het schrijven van geweldige code
+        Dan zou mijn account balans €1000010 zijn
 
-        # add all possibilities
-
+    Scenario: een artikel toevoegen aan mijn takenlijst
+        Gegeven mijn ziet mijn takenlijst er zo uit:
+        | TaakNaam            | Prioriteit |
+        | Fix bugs in my code | medium     |
+        | Document my hours   | medium     |
+        Wanneer ik de volgende taken toevoeg:
+        | TaakNaam                              | Prioriteit |
+        | Watch cat videos on YouTube all day   | high       |
+        Dan zou ik de volgende takenlijst zien:
+        | TaakNaam                              | Prioriteit |
+        | Watch cat videos on YouTube all day   | high       |
+        | Sign up for unemployment              | high       |

--- a/examples/typescript/specs/step-definitions/language.steps.ts
+++ b/examples/typescript/specs/step-definitions/language.steps.ts
@@ -1,0 +1,45 @@
+import { loadFeature, defineFeature } from '../../../../src/';
+import { PasswordValidator } from '../../src/password-validator';
+import { OnlineSales } from '../../src/online-sales';
+
+const feature = loadFeature('./examples/typescript/specs/features/language.feature');
+
+defineFeature(feature, (test) => {
+    let passwordValidator = new PasswordValidator();
+    let accessGranted = false;
+
+    beforeEach(() => {
+        passwordValidator = new PasswordValidator();
+    });
+
+    test('Invullen van een correct wachtwoord', ({ given, when, then }) => {
+        given('ik heb voorheen een wachtwoord aangemaakt', () => {
+            passwordValidator.setPassword('1234');
+        });
+
+        when('ik het correcte wachtwoord invoer', () => {
+            accessGranted = passwordValidator.validatePassword('1234');
+        });
+
+        then('krijg ik toegang', () => {
+            expect(accessGranted).toBe(true);
+        });
+    });
+
+    test('Verkoop <Artikel> voor €<Bedrag>', ({ given, when, then }) => {
+        let onlineSales = new OnlineSales();
+        let salesPrice: number | null;
+
+        given(/^ik heb een (.*)$/, (item) => {
+            onlineSales.listItem(item);
+        });
+
+        when(/^ik (.*) verkoop$/, (item) => {
+            salesPrice = onlineSales.sellItem(item);
+        });
+
+        then(/^zou ik €(\d+) ontvangen$/, (expectedSalesPrice) => {
+            expect(salesPrice).toBe(parseInt(expectedSalesPrice, 10));
+        });
+    });
+});

--- a/examples/typescript/specs/step-definitions/language.steps.ts
+++ b/examples/typescript/specs/step-definitions/language.steps.ts
@@ -1,45 +1,108 @@
 import { loadFeature, defineFeature } from '../../../../src/';
 import { PasswordValidator } from '../../src/password-validator';
 import { OnlineSales } from '../../src/online-sales';
+import { BankAccount } from '../../src/bank-account';
+import { TodoList } from '../../src/todo-list';
 
 const feature = loadFeature('./examples/typescript/specs/features/language.feature');
 
 defineFeature(feature, (test) => {
-    let passwordValidator = new PasswordValidator();
-    let accessGranted = false;
+    describe('basic-scenarios', () => {
+        let passwordValidator = new PasswordValidator();
+        let accessGranted = false;
 
-    beforeEach(() => {
-        passwordValidator = new PasswordValidator();
-    });
-
-    test('Invullen van een correct wachtwoord', ({ given, when, then }) => {
-        given('ik heb voorheen een wachtwoord aangemaakt', () => {
-            passwordValidator.setPassword('1234');
+        beforeEach(() => {
+            passwordValidator = new PasswordValidator();
         });
 
-        when('ik het correcte wachtwoord invoer', () => {
-            accessGranted = passwordValidator.validatePassword('1234');
-        });
+        test('Invullen van een correct wachtwoord', ({ given, when, then }) => {
+            given('ik heb voorheen een wachtwoord aangemaakt', () => {
+                passwordValidator.setPassword('1234');
+            });
 
-        then('krijg ik toegang', () => {
-            expect(accessGranted).toBe(true);
-        });
-    });
+            when('ik het correcte wachtwoord invoer', () => {
+                accessGranted = passwordValidator.validatePassword('1234');
+            });
 
-    test('Verkoop <Artikel> voor €<Bedrag>', ({ given, when, then }) => {
-        let onlineSales = new OnlineSales();
-        let salesPrice: number | null;
-
-        given(/^ik heb een (.*)$/, (item) => {
-            onlineSales.listItem(item);
-        });
-
-        when(/^ik (.*) verkoop$/, (item) => {
-            salesPrice = onlineSales.sellItem(item);
-        });
-
-        then(/^zou ik €(\d+) ontvangen$/, (expectedSalesPrice) => {
-            expect(salesPrice).toBe(parseInt(expectedSalesPrice, 10));
+            then('krijg ik toegang', () => {
+                expect(accessGranted).toBe(true);
+            });
         });
     });
+
+    describe('scenario-outlines', () => {
+        test('Verkoop <Artikel> voor €<Bedrag>', ({ given, when, then }) => {
+            let onlineSales = new OnlineSales();
+            let salesPrice: number | null;
+
+            given(/^ik heb een (.*)$/, (item) => {
+                onlineSales.listItem(item);
+            });
+
+            when(/^ik (.*) verkoop$/, (item) => {
+                salesPrice = onlineSales.sellItem(item);
+            });
+
+            then(/^zou ik €(\d+) ontvangen$/, (expectedSalesPrice) => {
+                expect(salesPrice).toBe(parseInt(expectedSalesPrice, 10));
+            });
+        });
+    });
+
+    describe('using-dynamic-values', () => {
+       let myAccount: BankAccount;
+
+        beforeEach(() => {
+            myAccount = new BankAccount();
+        });
+
+        test('Mijn salaris storten', ({ given, when, then, pending }) => {
+            given(/^mijn account balans is \€(\d+)$/, (balance) => {
+                myAccount.deposit(parseInt(balance, 10));
+            });
+
+            when(/^ik \€(\d+) krijg betaald voor het schrijven van geweldige code$/, (paycheck) => {
+                myAccount.deposit(parseInt(paycheck, 10));
+            });
+
+            then(/^zou mijn account balans \€(\d+) zijn$/, (expectedBalance) => {
+                expect(myAccount.balance).toBe(parseInt(expectedBalance, 10));
+            });
+        });
+    });
+
+    describe('using-gherkin-tables', () => {
+        let todoList: TodoList;
+
+        beforeEach(() => {
+            todoList = new TodoList();
+        });
+
+        test('een artikel toevoegen aan mijn takenlijst', ({ given, when, then }) => {
+            given('mijn ziet mijn takenlijst er zo uit:', (table: any[]) => {
+                table.forEach((row: any) => {
+                    todoList.add({
+                        name: row.TaakNaam,
+                        priority: row.Prioriteit,
+                    });
+                });
+            });
+
+            when('ik de volgende taken toevoeg:', (table: any) => {
+                todoList.add({
+                    name: table[0].TaakNaam,
+                    priority: table[0].Prioriteit,
+                });
+            });
+
+            then('zou ik de volgende takenlijst zien:', (table: any[]) => {
+                expect(todoList.items.length).toBe(table.length);
+
+                table.forEach((row: any, index) => {
+                    expect(todoList.items[index].name).toBe(table[index].TaakNaam);
+                    expect(todoList.items[index].priority).toBe(table[index].Prioriteit);
+                });
+            });
+        });
+    })
 });

--- a/src/parsed-feature-loading.ts
+++ b/src/parsed-feature-loading.ts
@@ -273,6 +273,9 @@ const translateKeywords = (astFeature: any) => {
             for (const step of child.scenario.steps) {
                 step.keyword = translationMap[step.keyword] || step.keyword;
             }
+            for (const example of child.scenario.examples) {
+                example.keyword = translationMap[example.keyword] || example.keyword;
+            }
         }
     }
 

--- a/src/parsed-feature-loading.ts
+++ b/src/parsed-feature-loading.ts
@@ -3,11 +3,13 @@ import { sync as globSync } from 'glob';
 import { dirname, resolve } from 'path';
 import callsites from 'callsites';
 import Parser from 'gherkin/dist/src/Parser';
+import { default as Gherkins } from 'gherkin';
 import AstBuilder from 'gherkin/dist/src/AstBuilder';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getJestCucumberConfiguration } from './configuration';
 import { ParsedFeature, ParsedScenario, ParsedStep, ParsedScenarioOutline, Options } from './models';
+import Dialect from 'gherkin/dist/src/Dialect';
 
 const parseDataTableRow = (astDataTableRow: any) => {
     return astDataTableRow.cells.map((col: any) => col.value) as string[];
@@ -255,6 +257,49 @@ const collapseRulesAndBackgrounds = (astFeature: any) => {
     };
 };
 
+const translateKeywords = (astFeature: any) => {
+    const languageDialect = Gherkins.dialects()[astFeature.language];
+    const translationMap = createTranslationMap(languageDialect);
+
+    astFeature.language = 'en';
+    astFeature.keyword = translationMap[astFeature.keyword] || astFeature.keyword;
+    for(const child of astFeature.children){
+        if(child.background) {
+            child.background.keyword = translationMap[child.background.keyword] || child.background.keyword;
+        }
+
+        if(child.scenario) {
+            child.scenario.keyword = translationMap[child.scenario.keyword] || child.scenario.keyword;
+            for (const step of child.scenario.steps) {
+                step.keyword = translationMap[step.keyword] || step.keyword;
+            }
+        }
+    }
+
+    return astFeature;
+};
+
+const createTranslationMap = (translateDialect: Dialect) => {
+    const englishDialect = Gherkins.dialects()['en'];
+    const translationMap: {[word: string]: string} = {};
+
+    const props: (keyof Dialect)[] = ['and', 'background', 'but', 'examples', 'feature', 'given', 'scenario', 'scenarioOutline', 'then', 'when', 'rule'];
+    for(const prop of props) {
+        const dialectWords = translateDialect[prop];
+        const translationWords = englishDialect[prop];
+        let index = 0;
+        for(const dialectWord of dialectWords){
+            if(dialectWord.indexOf('*') !== 0) {
+                translationMap[dialectWord] = translationWords[index];
+            }
+            index++;
+        }
+    }
+
+    return translationMap;
+}
+
+
 export const parseFeature = (featureText: string, options?: Options): ParsedFeature => {
     let ast: any;
 
@@ -265,7 +310,10 @@ export const parseFeature = (featureText: string, options?: Options): ParsedFeat
         throw new Error(`Error parsing feature Gherkin: ${err.message}`);
     }
 
-    const astFeature = collapseRulesAndBackgrounds(ast.feature);
+    let astFeature = collapseRulesAndBackgrounds(ast.feature);
+    if(astFeature.language !== 'en') {
+        astFeature = translateKeywords(astFeature);
+    }
 
     return {
         title: astFeature.name,


### PR DESCRIPTION
Added language support for when language is set other then the default 'en'.
Using `Gherkins.dialects()` to map the other language it's keywords to en-keywords.
Added a tests that covers most cases.

Also see: https://github.com/bencompton/jest-cucumber/issues/107