### PR TITLE
build: migrate to @cucumber/gherkin npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-cucumber",
-  "version": "2.0.11",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -360,6 +360,70 @@
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
+      }
+    },
+    "@cucumber/gherkin": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-17.0.2.tgz",
+      "integrity": "sha512-U8ZxbYVLEXqUy4Fx9BJ5ncIzXz/eVg+fKV2F8B1t5f6eDMgPQ2Aq3M8gy3yE422OAuJ+RFRuezNtuEbpmf2r4g==",
+      "requires": {
+        "@cucumber/messages": "^14.0.1",
+        "commander": "^7.1.0",
+        "source-map-support": "^0.5.19"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
+          "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg=="
+        }
+      }
+    },
+    "@cucumber/messages": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-14.0.1.tgz",
+      "integrity": "sha512-uCD/yP7P5em0KP1r59x6JayAxH7n8QXU9FbC3H8XMosZuM9z4PVLeU5pdJRkkCLFXqjpAZ3LJw65hlYDrBujEQ==",
+      "requires": {
+        "@types/uuid": "^8.3.0",
+        "protobufjs": "^6.10.2",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.47.tgz",
+          "integrity": "sha512-R6851wTjN1YJza8ZIeX6puNBSi/ZULHVh4WVleA7q256l+cP2EtXnKbO455fTs2ytQk3dL9qkU+Wh8l/uROdKg=="
+        },
+        "@types/uuid": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
+        },
+        "protobufjs": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
+          "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": "^13.7.0",
+            "long": "^4.0.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -922,9 +986,9 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
     },
     "@types/uuid": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
-      "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "@types/yargs": {
       "version": "15.0.5",
@@ -1900,11 +1964,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -1972,23 +2031,6 @@
           "version": "0.3.8",
           "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
           "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-        }
-      }
-    },
-    "cucumber-messages": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cucumber-messages/-/cucumber-messages-8.0.0.tgz",
-      "integrity": "sha512-lUnWRMjwA9+KhDec/5xRZV3Du67ISumHnVLywWQXyvzmc4P+Eqx8CoeQrBQoau3Pw1hs4kJLTDyV85hFBF00SQ==",
-      "requires": {
-        "@types/uuid": "^3.4.6",
-        "protobufjs": "^6.8.8",
-        "uuid": "^3.3.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -2533,16 +2575,6 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "gherkin": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/gherkin/-/gherkin-9.0.0.tgz",
-      "integrity": "sha512-6xoAepoxo5vhkBXjB4RCfVnSKHu5z9SqXIQVUyj+Jw8BQX8odATlee5otXgdN8llZvyvHokuvNiBeB3naEnnIQ==",
-      "requires": {
-        "commander": "^4.0.1",
-        "cucumber-messages": "8.0.0",
-        "source-map-support": "^0.5.16"
       }
     },
     "glob": {
@@ -4684,33 +4716,6 @@
         "sisteransi": "^1.0.4"
       }
     },
-    "protobufjs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
-      "integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
-        "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
-          "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw=="
-        }
-      }
-    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -5814,7 +5819,8 @@
     "uuid": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+      "optional": true
     },
     "v8-to-istanbul": {
       "version": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
     "typescript": "^3.3.3"
   },
   "dependencies": {
+    "@cucumber/gherkin": "^17.0.0",
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.7",
     "@types/node": "^11.9.4",
+    "@types/uuid": "^8.3.0",
     "callsites": "^3.0.0",
-    "gherkin": "^9.0.0",
     "glob": "^7.1.6",
-    "jest": "^26.1.0",
-    "uuid": "^8.2.0"
+    "jest": "^26.1.0"
   },
   "jest": {
     "transform": {

--- a/src/parsed-feature-loading.ts
+++ b/src/parsed-feature-loading.ts
@@ -2,14 +2,11 @@ import { readFileSync } from 'fs';
 import { sync as globSync } from 'glob';
 import { dirname, resolve } from 'path';
 import callsites from 'callsites';
-import Parser from 'gherkin/dist/src/Parser';
-import { default as Gherkins } from 'gherkin';
-import AstBuilder from 'gherkin/dist/src/AstBuilder';
+import { Parser, AstBuilder, Dialect, dialects } from '@cucumber/gherkin';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getJestCucumberConfiguration } from './configuration';
 import { ParsedFeature, ParsedScenario, ParsedStep, ParsedScenarioOutline, Options } from './models';
-import Dialect from 'gherkin/dist/src/Dialect';
 
 const parseDataTableRow = (astDataTableRow: any) => {
     return astDataTableRow.cells.map((col: any) => col.value) as string[];
@@ -258,7 +255,7 @@ const collapseRulesAndBackgrounds = (astFeature: any) => {
 };
 
 const translateKeywords = (astFeature: any) => {
-    const languageDialect = Gherkins.dialects()[astFeature.language];
+    const languageDialect = dialects[astFeature.language];
     const translationMap = createTranslationMap(languageDialect);
 
     astFeature.language = 'en';
@@ -286,7 +283,7 @@ const translateKeywords = (astFeature: any) => {
 };
 
 const createTranslationMap = (translateDialect: Dialect) => {
-    const englishDialect = Gherkins.dialects().en;
+    const englishDialect = dialects.en;
     const translationMap: {[word: string]: string} = {};
 
     const props: Array<keyof Dialect> = [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "outDir": "dist",
         "strict": true,
         "rootDir": ".",
-        "lib": ["esnext"]
+        "lib": ["esnext"],
+        "resolveJsonModule": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
The 'gherkin' npm package has been deprecated (even though it's not yet marked as such, see https://github.com/cucumber/cucumber/issues/1421). This PR updates it to the newest version in order to benefit from parser updates.