### PR TITLE
unit-test for translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "testMatch": [
-      "**/*.steps.ts"
+      "**/*.steps.ts",
+      "**/*.spec.ts"
     ],
     "moduleFileExtensions": [
       "js",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "jest": "jest --verbose",
-    "jest:unit": "jest **/*.spec.ts --verbose",
+    "jest": "npm run jest:unit & npm run jest:cucumber",
+    "jest:cucumber": "jest .*.steps.ts --verbose",
+    "jest:unit": "jest .*.spec.ts --verbose",
     "test": "npm run build & npm run lint & jest --color",
     "lint": "tslint --project ./"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "jest": "jest --verbose",
+    "jest:unit": "jest **/*.spec.ts --verbose",
     "test": "npm run build & npm run lint & jest --color",
     "lint": "tslint --project ./"
   },

--- a/specs/translation.spec.ts
+++ b/specs/translation.spec.ts
@@ -1,10 +1,10 @@
-import { Dialect, dialects, Parser } from '@cucumber/gherkin';
-import { translateKeywords } from './translation';
+import { Dialect, dialects } from '@cucumber/gherkin';
+import { translateKeywords } from '../src/translation';
 
 const StepKeywords: (keyof Dialect)[] = ['and', 'but', 'given', 'then', 'when'];
 
 describe('translation', () => {
-    // don't test languages that have duplicate keywords
+    // skip test languages that have duplicate keywords
     // See also: https://github.com/cucumber/cucumber/issues/1325
     const skipLanguages = ['uz'];
 
@@ -65,7 +65,7 @@ describe('translation', () => {
                 expect(astFeature.keyword).toEqual('Feature');
 
                 astFeature.children.filter((child) => 'background' in child)
-                    .forEach((child: any) => expect(child.background!.keyword).toEqual('Background'));
+                    .forEach((child: any) => expect(child.background.keyword).toEqual('Background'));
 
                 const translatedScenarioKeywords = astFeature.children.map((child) => child.scenario.keyword);
                 expect(translatedScenarioKeywords).toContain('Example');

--- a/src/parsed-feature-loading.ts
+++ b/src/parsed-feature-loading.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { sync as globSync } from 'glob';
 import { dirname, resolve } from 'path';
 import callsites from 'callsites';
-import { Parser, AstBuilder, Dialect, dialects } from '@cucumber/gherkin';
+import { Parser, AstBuilder } from '@cucumber/gherkin';
 import { v4 as uuidv4 } from 'uuid';
 import { translateKeywords } from './translation';
 

--- a/src/translation.spec.ts
+++ b/src/translation.spec.ts
@@ -1,0 +1,61 @@
+import { default as Gherkins } from 'gherkin';
+import Dialect from 'gherkin/dist/src/Dialect';
+import { translateKeywords } from './translation';
+
+const StepKeywords: (keyof Dialect)[] = ['and', 'but', 'given', 'then', 'when'];
+
+describe('translations', () => {
+    describe('translateKeywords', () => {
+
+        const languages = Object.keys(Gherkins.dialects())
+            .filter(language => language !== 'en')
+            .map(language => [language]);
+
+        test.each(languages)('when the language is %s', (languageCode) => {
+            const language = Gherkins.dialects()[languageCode];
+
+            const languageStepKeywords = Array.from(new Set(StepKeywords.map((keyword) => (language[keyword])).flat()));
+            let astFeature = {
+                language: languageCode,
+                // top level
+                keyword: language.feature[0],// TODO: all feature keywords
+                children: [
+                    {
+                        background: {
+                            keyword: language.background[0],// TODO: all background keywords
+                        },
+                        scenario: {
+                            // TODO: add rule
+                            keyword: language.scenario[0],// TODO: all scenario keywords
+                            steps: languageStepKeywords.map((stepKeyword) => ({
+                                keyword: stepKeyword
+                            })),
+                            examples: [{
+                                keyword: language.examples[0],
+                            }],
+                        },
+                    },
+                    {
+                        scenario: {
+                            keyword: language.scenarioOutline[0],// TODO: all scenarioOutline keywords
+                            steps: [],
+                            examples: [],
+                        },
+                    },
+                ],
+            }
+
+            astFeature = translateKeywords(astFeature);
+
+            expect(astFeature.keyword).toEqual('Feature');
+            expect(astFeature.children[0].background?.keyword).toEqual('Background');
+            if (!['uz', 'sl'].includes(languageCode)) {// TODO: not exclude uz en sl keyword checks
+                const translatedStepKeywords = Array.from(new Set((astFeature.children[0].scenario.steps as []).map((step: { keyword: string; }) => step.keyword)));
+                expect(translatedStepKeywords).toEqual(expect.arrayContaining(['* ', 'And ', 'But ', 'Given ', 'Then ', 'When ']));
+                // FIXME: Агар in 'uz' is 'given' and 'when'
+                // FIXME: there is no '* ' in 'sl'
+            }
+            expect(astFeature.children[0].scenario.examples[0].keyword).toEqual('Examples');//TODO: all examples keywords
+        });
+    });
+});

--- a/src/translation.spec.ts
+++ b/src/translation.spec.ts
@@ -3,11 +3,18 @@ import { translateKeywords } from './translation';
 
 const StepKeywords: (keyof Dialect)[] = ['and', 'but', 'given', 'then', 'when'];
 
-describe('translations', () => {
+describe('translation', () => {
+    // don't test languages that have duplicate keywords
+    // See also: https://github.com/cucumber/cucumber/issues/1325
+    const skipLanguages = ['uz'];
+
     describe('translateKeywords', () => {
 
         const languages = Object.keys(dialects)
+            // remove language where it is translated to
             .filter(language => language !== 'en')
+
+            .filter(language => !skipLanguages.includes(language))
             .map(language => [language]);
 
         test.each(languages)('when the language is %s', (languageCode) => {
@@ -16,7 +23,6 @@ describe('translations', () => {
             const languageStepKeywords = Array.from(new Set(StepKeywords.map((keyword) => (language[keyword])).flat()));
             let astFeature = {
                 language: languageCode,
-                // top level
                 keyword: language.feature[0],// TODO: all feature keywords
                 children: [
                     {
@@ -48,13 +54,19 @@ describe('translations', () => {
 
             expect(astFeature.keyword).toEqual('Feature');
             expect(astFeature.children[0].background?.keyword).toEqual('Background');
-            if (!['uz', 'sl'].includes(languageCode)) {// TODO: not exclude uz en sl keyword checks
-                const translatedStepKeywords = Array.from(new Set((astFeature.children[0].scenario.steps as []).map((step: { keyword: string; }) => step.keyword)));
-                expect(translatedStepKeywords).toEqual(expect.arrayContaining(['* ', 'And ', 'But ', 'Given ', 'Then ', 'When ']));
-                // FIXME: Агар in 'uz' is 'given' and 'when'
-                // FIXME: there is no '* ' in 'sl'
+            const translatedStepKeywords = Array.from(new Set((astFeature.children[0].scenario.steps as []).map((step: { keyword: string; }) => step.keyword)));
+            const expectedStepKeywords = ['* ', 'And ', 'But ', 'Given ', 'Then ', 'When '];
+            if (languageCode === 'sl') {
+                // exception for 'sl' language, this don't have '*' set
+                // See also https://github.com/cucumber/cucumber/issues/1325
+                expectedStepKeywords.shift();
             }
+            expect(translatedStepKeywords).toEqual(expect.arrayContaining(expectedStepKeywords));
             expect(astFeature.children[0].scenario.examples[0].keyword).toEqual('Examples');//TODO: all examples keywords
         });
+
+        skipLanguages.forEach((skipLanguage) => {
+            test.skip('when the language is ' + skipLanguages, (languageCode) => { });
+        })
     });
 });

--- a/src/translation.spec.ts
+++ b/src/translation.spec.ts
@@ -22,31 +22,41 @@ describe('translation', () => {
 
             const languageStepKeywords = Array.from(new Set(StepKeywords.map((keyword) => (language[keyword])).flat()));
 
+            // test per feature keyword
             for (const feature of language.feature) {
+                const backgroundChildren = language.background.map((background) => ({
+                    background: {
+                        keyword: background,
+                    },
+                    scenario: {
+                        keyword: language.scenario[0],
+                        steps: [],
+                        examples: [],
+                    }
+                }));
+                const scenarioChildren = language.scenario.map((scenario) => ({
+                    scenario: {
+                        keyword: scenario,
+                        steps: languageStepKeywords.map((stepKeyword) => ({
+                            keyword: stepKeyword
+                        })),
+                        examples: language.examples.map((example) => ({ keyword: example, })),
+                    },
+                }));
+
                 let astFeature = {
                     language: languageCode,
                     keyword: feature,
                     children: [
-                        {
-                            background: {
-                                keyword: language.background[0],// TODO: all background keywords
-                            },
-                            scenario: {
-                                // TODO: add rule
-                                keyword: language.scenario[0],// TODO: all scenario keywords
-                                steps: languageStepKeywords.map((stepKeyword) => ({
-                                    keyword: stepKeyword
-                                })),
-                                examples: language.examples.map((example) => ({ keyword: example, })),
-                            },
-                        },
+                        ...scenarioChildren,
                         ...language.scenarioOutline.map((scenarioOutline) => ({
                             scenario: {
                                 keyword: scenarioOutline,
                                 steps: [],
                                 examples: [],
                             },
-                        }))
+                        })),
+                        ...backgroundChildren,
                     ],
                 }
 

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -1,8 +1,10 @@
 import { Dialect, dialects } from '@cucumber/gherkin';
+const englishDialect = dialects.en
 
-const createTranslationMap = (translateDialect: Dialect) => {
-    const englishDialect = dialects.en;
-    const translationMap: { [word: string]: string } = {};
+type TranslationMap = { [word: string]: string };
+
+const createTranslationMap = (translateDialect: Dialect): TranslationMap => {
+    const translationMap: TranslationMap = {};
 
     const props: Array<keyof Dialect> = [
         'and',
@@ -21,13 +23,17 @@ const createTranslationMap = (translateDialect: Dialect) => {
     for (const prop of props) {
         const dialectWords = translateDialect[prop];
         const translationWords = englishDialect[prop];
+
+        // it does not matter where the word is translated to,
+        // just get the first non-'*' word
         const defaultTranslation = getDefaultTranslation(translationWords as string[]);
 
         for (const dialectWord of dialectWords) {
             // don't translate *
-            if (dialectWord.indexOf('*') !== 0) {
-                translationMap[dialectWord] = defaultTranslation;
+            if (dialectWord.indexOf('*') === 0) {
+                continue;
             }
+            translationMap[dialectWord] = defaultTranslation;
         }
     }
 

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -1,0 +1,70 @@
+import { default as Gherkins } from 'gherkin';
+import Dialect from 'gherkin/dist/src/Dialect';
+
+const createTranslationMap = (translateDialect: Dialect) => {
+    const englishDialect = Gherkins.dialects().en;
+    const translationMap: { [word: string]: string } = {};
+
+    const props: Array<keyof Dialect> = [
+        'and',
+        'background',
+        'but',
+        'examples',
+        'feature',
+        'given',
+        'scenario',
+        'scenarioOutline',
+        'then',
+        'when',
+        'rule',
+    ];
+
+    for (const prop of props) {
+        const dialectWords = translateDialect[prop];
+        const translationWords = englishDialect[prop];
+        const defaultTranslation = getDefaultTranslation(translationWords as string[]);
+
+        for (const dialectWord of dialectWords) {
+            // don't translate *
+            if (dialectWord.indexOf('*') !== 0) {
+                translationMap[dialectWord] = defaultTranslation;
+            }
+        }
+    }
+
+    return translationMap;
+};
+
+const getDefaultTranslation = (translationWords: string[]): string => {
+    return translationWords.find(word => !word.includes('*'))!;
+};
+
+export const translateKeywords = (astFeature: any) => {
+    const languageDialect = Gherkins.dialects()[astFeature.language];
+    const translationMap = createTranslationMap(languageDialect);
+
+    // replace language
+    astFeature.language = 'en';
+    // update top level
+    astFeature.keyword = translationMap[astFeature.keyword] || astFeature.keyword;
+
+    for (const child of astFeature.children) {
+        if (child.background) {
+            child.background.keyword = translationMap[child.background.keyword] || child.background.keyword;
+        }
+
+        if (child.scenario) {
+            child.scenario.keyword = translationMap[child.scenario.keyword] || child.scenario.keyword;
+
+            for (const step of child.scenario.steps) {
+                step.keyword = translationMap[step.keyword] || step.keyword;
+            }
+
+            for (const example of child.scenario.examples) {
+                example.keyword = translationMap[example.keyword] || example.keyword;
+            }
+        }
+    }
+
+    return astFeature;
+};

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -1,4 +1,7 @@
 import { Dialect, dialects } from '@cucumber/gherkin';
+
+// only translation props 
+type DialectTranslationProps = keyof Pick<Dialect, 'and' | 'background' | 'but' | 'examples' | 'feature' | 'given' | 'scenario' | 'scenarioOutline' | 'then' | 'when' | 'rule'>;
 const englishDialect = dialects.en
 
 type TranslationMap = { [word: string]: string };
@@ -6,7 +9,7 @@ type TranslationMap = { [word: string]: string };
 const createTranslationMap = (translateDialect: Dialect): TranslationMap => {
     const translationMap: TranslationMap = {};
 
-    const props: Array<keyof Dialect> = [
+    const props: DialectTranslationProps[] = [
         'and',
         'background',
         'but',
@@ -22,11 +25,9 @@ const createTranslationMap = (translateDialect: Dialect): TranslationMap => {
 
     for (const prop of props) {
         const dialectWords = translateDialect[prop];
-        const translationWords = englishDialect[prop];
-
         // it does not matter where the word is translated to,
         // just get the first non-'*' word
-        const defaultTranslation = getDefaultTranslation(translationWords as string[]);
+        const defaultTranslation = getDefaultTranslation(englishDialect[prop]);
 
         for (const dialectWord of dialectWords) {
             // don't translate *
@@ -40,7 +41,7 @@ const createTranslationMap = (translateDialect: Dialect): TranslationMap => {
     return translationMap;
 };
 
-const getDefaultTranslation = (translationWords: string[]): string => {
+const getDefaultTranslation = (translationWords: readonly string[]): string => {
     return translationWords.find(word => !word.includes('*'))!;
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,8 @@
     },
     "exclude": [
         "node_modules",
-        "examples/ecmascript",
+        "examples",
         "dist",
-        "*.spec.ts"
+        "specs"
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,14 @@
         "outDir": "dist",
         "strict": true,
         "rootDir": ".",
-        "lib": ["esnext"]
+        "lib": [
+            "esnext"
+        ]
     },
     "exclude": [
         "node_modules",
         "examples/ecmascript",
-        "dist"
+        "dist",
+        "*.spec.ts"
     ]
 }


### PR DESCRIPTION
Hi,

I have changed:
- added a unit-test for the translation
- split translation-specific functions to a seperate file
- added some changes in your package.json to test the unit-tests sperate from the cucumber tests
- added some excludes in the tsconfig, not to include test-data
- fix for translating keyword to the first available english translation. Languages have different lengths of translations, before I translated the second word to the second word in english. This made the code more complex and possible to error. Because different languages have more or less translations than in english. Found this because of the unit-test ;-)

I hope this is to your liking, otherwise feel free to rearrange some config :)
P.S. my ide may have reformatted some code, rearrange it yourself is you want to.