### PR TITLE
Allow steps in autoBindSteps to be registered locally instead of globally

### DIFF
--- a/src/automatic-step-binding.ts
+++ b/src/automatic-step-binding.ts
@@ -5,11 +5,10 @@ import { generateStepCode } from './code-generation/step-generation';
 
 const globalSteps: Array<{ stepMatcher: string | RegExp, stepFunction: () => any }> = [];
 
-const registerStep = (stepMatcher: string | RegExp, stepFunction: () => any) => {
-    globalSteps.push({ stepMatcher, stepFunction });
-};
+export const autoBindSteps = (features: ParsedFeature[], stepDefinitions: StepsDefinitionCallbackFunction[], registerStepsGlobally: boolean = true) => {
+    const steps = registerStepsGlobally? globalSteps : [];
+    const registerStep = (stepMatcher: string | RegExp, stepFunction: () => any) => steps.push({ stepMatcher, stepFunction });
 
-export const autoBindSteps = (features: ParsedFeature[], stepDefinitions: StepsDefinitionCallbackFunction[]) => {
     stepDefinitions.forEach((stepDefinitionCallback) => {
         stepDefinitionCallback({
             defineStep: registerStep,
@@ -36,7 +35,7 @@ export const autoBindSteps = (features: ParsedFeature[], stepDefinitions: StepsD
             scenarios.forEach((scenario) => {
                 test(scenario.title, (options) => {
                     scenario.steps.forEach((step, stepIndex) => {
-                        const matches = globalSteps
+                        const matches = steps
                             .filter((globalStep) => matchSteps(step.stepText, globalStep.stepMatcher));
 
                         if (matches.length === 1) {


### PR DESCRIPTION
I have a use case where each call to `autoBindSteps` will have its own definitions. Some of these definitions have same patterns. Currently, `autoBindSteps` registers each step definition globally, which causes errors like the following:

> 2 step definition matches were found for step "I should be granted access" in scenario "Entering a correct password" in feature "Logging in". Each step can only have one matching step definition. The following step definition matches were found:

By providing a flag to disable global registration (which remains the default, to prevent breaking anything), each call to `autoBindSteps` will have its own private registration.