### PR TITLE
added flag for concurrent execution

### DIFF
--- a/docs/AutomaticStepBinding.md
+++ b/docs/AutomaticStepBinding.md
@@ -108,3 +108,14 @@ If you are using `autoBindSteps` with just a subset of your feature files (as de
 `loadFeatures` and `autoBindSteps` are utility functions that automate what you would normally do per feature file by calling `loadFeature`, then `defineFeature`, and then defining one `test` per scenario containing inline step definitions.
 
 `loadFeatures` will load multiple feature files specified in your glob pattern and `autoBindSteps` will loop through every feature file, calling `defineFeature` for each one. It will then call `test` for each scenario within each feature file, and will loop through the steps in each scenario, attempting to match the steps with with one of the step definitions within the functions you are binding. If no matching step definition is found for a particular step, or more than one matching step definition is found, errors will occur.
+
+## Concurrent execution with autobind
+
+With Jest, you can use `test.concurrent('test run concurrently', () => { ... })` to concurrenly execute multiple tests in the same file. Though its still an experimental feature of Jest with a few known issues, `jest-cucumber` includes this feature into `autobinds` with a flag incase required.
+
+
+```javascript
+  "jest": {
+    ...
+    autoBindSteps(features, [ countDownSteps ], true);
+```

--- a/docs/AutomaticStepBinding.md
+++ b/docs/AutomaticStepBinding.md
@@ -115,7 +115,7 @@ With Jest, you can use `test.concurrent('test run concurrently', () => { ... })`
 
 
 ```javascript
-  "jest": {
     ...
     autoBindSteps(features, [ countDownSteps ], true);
+    ...
 ```

--- a/examples/ecmascript/specs/features/auto-binding-concurrent/launch-2-seconds-countdown.feature
+++ b/examples/ecmascript/specs/features/auto-binding-concurrent/launch-2-seconds-countdown.feature
@@ -1,0 +1,6 @@
+Feature: Launch countdown
+
+    Scenario: Setting 2 seconds countdown 
+        Given I have set a "2" seconds countdown for my satellite
+        When I start the countdown
+        Then my satellite should be launched to space on countdown completion

--- a/examples/ecmascript/specs/features/auto-binding-concurrent/launch-4-seconds-countdown.feature
+++ b/examples/ecmascript/specs/features/auto-binding-concurrent/launch-4-seconds-countdown.feature
@@ -1,0 +1,6 @@
+Feature: Launch countdown
+
+    Scenario: Setting 4 seconds countdown
+        Given I have set a "4" seconds countdown for my satellite
+        When I start the countdown
+        Then my satellite should be launched to space on countdown completion

--- a/examples/ecmascript/specs/step-definitions/auto-step-binding-concurrent.steps.js
+++ b/examples/ecmascript/specs/step-definitions/auto-step-binding-concurrent.steps.js
@@ -1,0 +1,27 @@
+import { loadFeatures, autoBindSteps } from 'jest-cucumber';
+import { SatelliteLaunch } from '../../src/satellite-launch-countdown';
+
+export const countDownSteps = ({ given, and, when, then }) => {
+    
+    given(/^I have set a "(.*)" seconds countdown for my satellite$/, (countDownSeconds) => {
+        const satelliteLaunch = new SatelliteLaunch();
+        satelliteLaunch.setCountDown(countDownSeconds)
+        
+        // Jest concurrent execution is still experimental due to which beforeEach, afterEach annotations doesnt work. Hence using Jest's setState to pass values between test steps
+        expect.setState({satelliteLaunch})
+    });
+
+    when('I start the countdown', () => {
+        return new Promise((resolve, reject)=> {
+            resolve(expect.getState().satelliteLaunch.startCountDown())
+        })
+    });
+
+    then('my satellite should be launched to space on countdown completion', () => {
+        expect(expect.getState().satelliteLaunch.getSatelliteLocation()).toBe('space');
+    });
+};
+
+const features = loadFeatures('./specs/features/auto-binding-concurrent/*.feature');
+
+autoBindSteps(features, [ countDownSteps ], true);

--- a/examples/ecmascript/src/satellite-launch-countdown.js
+++ b/examples/ecmascript/src/satellite-launch-countdown.js
@@ -1,0 +1,23 @@
+export class SatelliteLaunch {
+    constructor() {
+        this.countDown = 0;
+        this.satelliteLocation = 'station'
+    }
+
+    setCountDown(seconds) {
+        this.countDown = seconds
+    }
+
+    startCountDown() {
+        return new Promise((resolve, reject) =>{
+            setTimeout(()=>{
+                this.satelliteLocation = 'space'
+                resolve()
+            }, Number(this.countDown)* 1000)
+        })
+    }
+
+    getSatelliteLocation() {
+        return this.satelliteLocation
+    }
+}

--- a/examples/typescript/specs/features/auto-binding-concurrent/launch-2-seconds-countdown.feature
+++ b/examples/typescript/specs/features/auto-binding-concurrent/launch-2-seconds-countdown.feature
@@ -1,0 +1,6 @@
+Feature: Launch 2 secs countdown
+
+    Scenario: Setting 2 seconds countdown 
+        Given I have set a "2" seconds countdown for my satellite
+        When I start the countdown
+        Then my satellite should be launched to space on countdown completion

--- a/examples/typescript/specs/features/auto-binding-concurrent/launch-4-seconds-countdown.feature
+++ b/examples/typescript/specs/features/auto-binding-concurrent/launch-4-seconds-countdown.feature
@@ -1,0 +1,6 @@
+Feature: Launch 4 secs countdown
+
+    Scenario: Setting 4 seconds countdown
+        Given I have set a "4" seconds countdown for my satellite
+        When I start the countdown
+        Then my satellite should be launched to space on countdown completion

--- a/examples/typescript/specs/step-definitions/auto-step-binding-concurrent.steps.ts
+++ b/examples/typescript/specs/step-definitions/auto-step-binding-concurrent.steps.ts
@@ -1,0 +1,27 @@
+import { StepDefinitions, loadFeatures, autoBindSteps } from '../../../../src';
+import { SatelliteLaunch } from '../../src/satellite-launch-countdown';
+
+export const countDownSteps: StepDefinitions = ({ given, and, when, then }) => {
+    given(/^I have set a "(.*)" seconds countdown for my satellite$/, (countDownSeconds) => {
+        const satelliteLaunch = new SatelliteLaunch();
+        satelliteLaunch.setCountDown(Number(countDownSeconds));
+        /* Jest concurrent execution is still experimental due to which beforeEach,
+        afterEach annotations doesnt work. Hence using Jest's setState to pass
+        values between test steps*/
+        expect.setState({satelliteLaunch});
+    });
+
+    when('I start the countdown', () => {
+        return new Promise((resolve, reject) => {
+            resolve(expect.getState().satelliteLaunch.startCountDown());
+        });
+    });
+
+    then('my satellite should be launched to space on countdown completion', () => {
+        expect(expect.getState().satelliteLaunch.getSatelliteLocation()).toBe('space');
+    });
+};
+
+const features = loadFeatures('./examples/typescript/specs/features/auto-binding-concurrent/**/*.feature');
+
+autoBindSteps(features, [ countDownSteps ], true);

--- a/examples/typescript/src/satellite-launch-countdown.ts
+++ b/examples/typescript/src/satellite-launch-countdown.ts
@@ -1,0 +1,21 @@
+export class SatelliteLaunch {
+    public countDown: number = 0;
+    public satelliteLocation: string = 'station';
+
+    public setCountDown(seconds: number) {
+        this.countDown = seconds;
+    }
+
+    public startCountDown() {
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                this.satelliteLocation = 'space';
+                resolve('');
+            }, Number(this.countDown) * 1000);
+        });
+    }
+
+    public getSatelliteLocation() {
+        return this.satelliteLocation;
+    }
+}

--- a/src/automatic-step-binding.ts
+++ b/src/automatic-step-binding.ts
@@ -9,10 +9,10 @@ const registerStep = (stepMatcher: string | RegExp, stepFunction: () => any) => 
     globalSteps.push({ stepMatcher, stepFunction });
 };
 
-export const createAutoBindSteps = (jestLike: IJestLike, concurrent = false) => {
+export const createAutoBindSteps = (jestLike: IJestLike) => {
     const defineFeature = createDefineFeature(jestLike);
 
-    return (features: ParsedFeature[], stepDefinitions: StepsDefinitionCallbackFunction[]) => {
+    return (features: ParsedFeature[], stepDefinitions: StepsDefinitionCallbackFunction[], concurrent=false) => {
         stepDefinitions.forEach((stepDefinitionCallback) => {
             stepDefinitionCallback({
                 defineStep: registerStep,

--- a/src/automatic-step-binding.ts
+++ b/src/automatic-step-binding.ts
@@ -9,7 +9,7 @@ const registerStep = (stepMatcher: string | RegExp, stepFunction: () => any) => 
     globalSteps.push({ stepMatcher, stepFunction });
 };
 
-export const autoBindSteps = (features: ParsedFeature[], stepDefinitions: StepsDefinitionCallbackFunction[]) => {
+export const autoBindSteps = (features: ParsedFeature[], stepDefinitions: StepsDefinitionCallbackFunction[], concurrent = false) => {
     stepDefinitions.forEach((stepDefinitionCallback) => {
         stepDefinitionCallback({
             defineStep: registerStep,
@@ -34,7 +34,8 @@ export const autoBindSteps = (features: ParsedFeature[], stepDefinitions: StepsD
             const scenarios = [...feature.scenarios, ...scenarioOutlineScenarios];
 
             scenarios.forEach((scenario) => {
-                test(scenario.title, (options) => {
+                const testExecution = concurrent ? test.concurrent : test
+                testExecution(scenario.title, (options) => {
                     scenario.steps.forEach((step, stepIndex) => {
                         const matches = globalSteps
                             .filter((globalStep) => matchSteps(step.stepText, globalStep.stepMatcher));

--- a/src/automatic-step-binding.ts
+++ b/src/automatic-step-binding.ts
@@ -9,7 +9,10 @@ const registerStep = (stepMatcher: string | RegExp, stepFunction: () => any) => 
     globalSteps.push({ stepMatcher, stepFunction });
 };
 
-export const autoBindSteps = (features: ParsedFeature[], stepDefinitions: StepsDefinitionCallbackFunction[], concurrent = false) => {
+export const autoBindSteps = (
+    features: ParsedFeature[],
+    stepDefinitions: StepsDefinitionCallbackFunction[],
+    concurrent = false) => {
     stepDefinitions.forEach((stepDefinitionCallback) => {
         stepDefinitionCallback({
             defineStep: registerStep,
@@ -34,7 +37,7 @@ export const autoBindSteps = (features: ParsedFeature[], stepDefinitions: StepsD
             const scenarios = [...feature.scenarios, ...scenarioOutlineScenarios];
 
             scenarios.forEach((scenario) => {
-                const testExecution = concurrent ? test.concurrent : test
+                const testExecution = concurrent ? test.concurrent : test;
                 testExecution(scenario.title, (options) => {
                     scenario.steps.forEach((step, stepIndex) => {
                         const matches = globalSteps


### PR DESCRIPTION
Change: added a flag to utilise Jest's `test.concurrent` functionality.

Related to: https://github.com/bencompton/jest-cucumber/issues/53

Added tests (both JS & TS) & ensured that it doesnt break anything existing


**Test outcome:**

_Concurrent execution_

```
...
const features = loadFeatures('./examples/typescript/specs/features/auto-binding-concurrent/**/*.feature');
autoBindSteps(features, [ countDownSteps ]);
...
```
TimeTaken:  (5.9s)

![Screenshot 2022-01-10 at 05 12 33](https://user-images.githubusercontent.com/71319212/148721069-18b408db-2b5b-4f54-a8a4-b0d829248416.png)

_Execution in sequence_

```
...
const features = loadFeatures('./examples/typescript/specs/features/auto-binding-concurrent/**/*.feature');
autoBindSteps(features, [ countDownSteps ]);
...
```
TimeTaken:  (7.4 s)

![Screenshot 2022-01-10 at 05 12 39](https://user-images.githubusercontent.com/71319212/148720998-906f94ac-09d7-4384-abe9-7b94e90288b2.png)
