### PR TITLE
Fix scenario outline title placeholder to work with autoBindSteps

### DIFF
--- a/examples/typescript/specs/step-definitions/auto-step-binding-outline.steps.ts
+++ b/examples/typescript/specs/step-definitions/auto-step-binding-outline.steps.ts
@@ -1,0 +1,27 @@
+import { StepDefinitions, autoBindSteps, loadFeature } from '../../../../src';
+import { OnlineSales } from '../../src/online-sales';
+
+export const salesSteps: StepDefinitions = ({ given, when, then }) => {
+  let onlineSales: OnlineSales;
+  let salesPrice: number | null;
+
+  beforeEach(() => {
+    onlineSales = new OnlineSales();
+  });
+
+  given(/^I have a\(n\) (.+)$/, (item: string) => {
+    onlineSales.listItem(item);
+  });
+
+  when(/^I sell the (.+)$/, (item: string) => {
+    salesPrice = onlineSales.sellItem(item);
+  });
+
+  then(/^I should get \$(\d+)$/, (expectedSalesPrice: string) => {
+    expect(salesPrice).toBe(parseInt(expectedSalesPrice, 10));
+  });
+};
+
+const feature = loadFeature('./examples/typescript/specs/features/scenario-outlines.feature');
+
+autoBindSteps([feature], [salesSteps]);

--- a/src/automatic-step-binding.ts
+++ b/src/automatic-step-binding.ts
@@ -31,7 +31,12 @@ export const createAutoBindSteps = (jestLike: IJestLike) => {
 
     features.forEach(feature => {
       defineFeature(feature, test => {
-        const scenarioOutlineScenarios = feature.scenarioOutlines.map(scenarioOutline => scenarioOutline.scenarios[0]);
+        const scenarioOutlineScenarios = feature.scenarioOutlines.map(scenarioOutline => ({
+          ...scenarioOutline.scenarios[0],
+          // we need to use the original title with un-expanded placeholders,
+          // otherwise it will try to match the expanded version in the feature file and fail.
+          title: scenarioOutline.title,
+        }));
 
         const scenarios = [...feature.scenarios, ...scenarioOutlineScenarios];
 


### PR DESCRIPTION
Fixes #101 

Opened a new PR on current master in favor of https://github.com/bencompton/jest-cucumber/pull/142.

To try and install this version locally, run
```sh
npm install --save-dev Papooch/jest-cucumber#dist
```

---
1) Checkout the firs commit, run `npm run test`
2) See test fail with `Feature file has a scenario titled "Selling an <Item> at $<Amount>", but no match found in step definitions.`
3) Checkout second commit, see all tests pass.