### PR TITLE
Fix no build before npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,15 +1,31 @@
 name: npm-publish
+
 on:
   push:
     branches:
       - master
+
 jobs:
   npm-publish:
-    name: npm-publish
+    name: Npm Publish
     runs-on: ubuntu-latest
+
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
+    - name: Setup Node v20.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
+
+      # https://docs.npmjs.com/cli/v10/commands/npm-ci
+    - name: Install Package
+      run: npm ci
+
+    - name: Build Project
+      run: npm run build
+
     - name: Publish if version has been updated
       uses: pascalgn/npm-publish-action@1.3.9
       env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "jest-cucumber",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-cucumber",
-      "version": "4.0.1",
-      "license": "MIT",
+      "version": "4.0.2",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/gherkin": "^17.0.0",
         "callsites": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-cucumber",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Execute Gherkin scenarios in Jest",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",


### PR DESCRIPTION
Hello @bencompton ,

Sorry for the direct mention, but there's a big problem with the github publish action. The build step is missing, which means the dist folder isn't published to the npm registry.\
This makes the library unusable.

![image](https://github.com/bencompton/jest-cucumber/assets/107397730/fb10fb39-8451-40a0-b3e5-a23a059d1ed7)

I suggest this quick fix to quickly fix and republish a patched version.