### PR TITLE
Use npm to publish package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,11 +29,10 @@ jobs:
     - name: Build Project
       run: npm run build
 
-    - name: Remove node_modules
-      run: rm -Rf node_modules
-
     - name: Publish if version has been updated
       uses: pascalgn/npm-publish-action@1.3.9
+      with:
+        publish_command: "npm"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_AUTH_TOKEN: ${{ secrets.JEST_CUCUMBER_NPM_TOKEN }}


### PR DESCRIPTION
The github action you set up https://github.com/pascalgn/npm-publish-action/blob/master/Dockerfile uses version 12 of node with yarn 1.

So I wonder if yarn isn't causing the problem because it's used by default.

So I've configured it to use npm as you were able to use it locally without any problems, which should work, or so I hope.

I'm really sorry for all the problems, it's the first time that using husky has caused me problems.

As a last resort we could temporarily remove husky until we find a permanent solution. 
