### PR TITLE
Enhancement: Update autoBindSteps to Support Single .feature File

### DIFF
--- a/docs/AutomaticStepBinding.md
+++ b/docs/AutomaticStepBinding.md
@@ -103,6 +103,17 @@ If you are using `autoBindSteps` with just a subset of your feature files (as de
     ],
 ```
 
+It's also possible to load a single feature via `autoBinSteps`, so you can keep the test parallelization that jest offers.
+
+```javascript
+import { loadFeature, autoBindSteps } from 'jest-cucumber';
+
+import { vendingMachineSteps } from 'specs/step-definitions/vending-machine-steps';
+
+const feature = loadFeature('specs/features/vending-machine.feature');
+autoBindSteps(feature, [ vendingMachineSteps ]);
+```
+
 ## How it works
 
 `loadFeatures` and `autoBindSteps` are utility functions that automate what you would normally do per feature file by calling `loadFeature`, then `defineFeature`, and then defining one `test` per scenario containing inline step definitions.

--- a/examples/typescript/specs/step-definitions/auto-binding/auto-step-binding-beverage-vending.steps.ts
+++ b/examples/typescript/specs/step-definitions/auto-binding/auto-step-binding-beverage-vending.steps.ts
@@ -1,5 +1,5 @@
-import { StepDefinitions, loadFeatures, autoBindSteps } from '../../../../src';
-import { VendingMachine } from '../../src/vending-machine';
+import { StepDefinitions, loadFeature, autoBindSteps } from '../../../../../src';
+import { VendingMachine } from '../../../src/vending-machine';
 
 export const vendingMachineSteps: StepDefinitions = ({ given, and, when, then }) => {
   let vendingMachine: VendingMachine;
@@ -23,6 +23,6 @@ export const vendingMachineSteps: StepDefinitions = ({ given, and, when, then })
   });
 };
 
-const features = loadFeatures('./examples/typescript/specs/features/auto-binding/**/*.feature');
+const features = loadFeature('./examples/typescript/specs/features/auto-binding/beverage-vending-machine.feature');
 
 autoBindSteps(features, [vendingMachineSteps]);

--- a/examples/typescript/specs/step-definitions/auto-binding/auto-step-binding.steps.ts
+++ b/examples/typescript/specs/step-definitions/auto-binding/auto-step-binding.steps.ts
@@ -1,0 +1,28 @@
+import { StepDefinitions, loadFeatures, autoBindSteps } from '../../../../../src';
+import { VendingMachine } from '../../../src/vending-machine';
+
+export const vendingMachineSteps: StepDefinitions = ({ given, and, when, then }) => {
+  let vendingMachine: VendingMachine;
+
+  given(/^the vending machine has "(.*)" in stock$/, (itemName: string) => {
+    vendingMachine = new VendingMachine();
+    vendingMachine.stockItem(itemName, 1);
+  });
+
+  and('I have inserted the correct amount of money', () => {
+    vendingMachine.insertMoney(0.5);
+  });
+
+  when(/^I purchase "(.*)"$/, (itemName: string) => {
+    vendingMachine.dispenseItem(itemName);
+  });
+
+  then(/^my "(.*)" should be dispensed$/, (itemName: string) => {
+    const inventoryAmount = vendingMachine.items[itemName];
+    expect(inventoryAmount).toBe(0);
+  });
+};
+
+const features = loadFeatures('./examples/typescript/specs/features/auto-binding/**/*.feature');
+
+autoBindSteps(features, [vendingMachineSteps]);

--- a/src/automatic-step-binding.ts
+++ b/src/automatic-step-binding.ts
@@ -12,7 +12,12 @@ const registerStep = (stepMatcher: string | RegExp, stepFunction: () => unknown)
 export const createAutoBindSteps = (jestLike: IJestLike) => {
   const defineFeature = createDefineFeature(jestLike);
 
-  return (features: ParsedFeature[], stepDefinitions: StepsDefinitionCallbackFunction[]) => {
+  return (parsedFeatures: ParsedFeature | ParsedFeature[], stepDefinitions: StepsDefinitionCallbackFunction[]) => {
+    let features = parsedFeatures;
+    if (!Array.isArray(features)) {
+      features = [features];
+    }
+
     stepDefinitions.forEach(stepDefinitionCallback => {
       stepDefinitionCallback({
         defineStep: registerStep,


### PR DESCRIPTION
This PR updates the `autoBindSteps` function to support a single `.feature` file. 

The aim is to maintain Jest's parallelization capabilities, by making it possible to create a steps file with `autoBindSteps`.