### PR TITLE
Add Shared Context Capability to Step Definitions

### DIFF
--- a/examples/typescript/specs/step-definitions/auto-binding/auto-step-binding-snack-vending-use-context.steps.ts
+++ b/examples/typescript/specs/step-definitions/auto-binding/auto-step-binding-snack-vending-use-context.steps.ts
@@ -1,0 +1,30 @@
+import { autoBindSteps, loadFeature, StepDefinitionsWithContext } from '../../../../../src';
+import { VendingMachine } from '../../../src/vending-machine';
+
+type Context = {
+  vendingMachine: VendingMachine;
+};
+
+export const vendingMachineSteps: StepDefinitionsWithContext<Context> = ({ given, and, when, then, context }) => {
+  given(/^the vending machine has "(.*)" in stock$/, (itemName: string) => {
+    context.vendingMachine = new VendingMachine();
+    context.vendingMachine.stockItem(itemName, 1);
+  });
+
+  and('I have inserted the correct amount of money', () => {
+    context.vendingMachine.insertMoney(0.5);
+  });
+
+  when(/^I purchase "(.*)"$/, (itemName: string) => {
+    context.vendingMachine.dispenseItem(itemName);
+  });
+
+  then(/^my "(.*)" should be dispensed$/, (itemName: string) => {
+    const inventoryAmount = context.vendingMachine.items[itemName];
+    expect(inventoryAmount).toBe(0);
+  });
+};
+
+const features = loadFeature('./examples/typescript/specs/features/auto-binding/snack-vending-machine.feature');
+
+autoBindSteps(features, [vendingMachineSteps]);

--- a/src/automatic-step-binding.ts
+++ b/src/automatic-step-binding.ts
@@ -1,6 +1,10 @@
 import { ParsedFeature } from './models';
 import { matchSteps } from './validation/step-definition-validation';
-import { StepsDefinitionCallbackFunction, createDefineFeature, IJestLike } from './feature-definition-creation';
+import {
+  createDefineFeature,
+  IJestLike,
+  type StepsDefinitionCallbackFunctionWithContext,
+} from './feature-definition-creation';
 import { generateStepCode } from './code-generation/step-generation';
 
 const globalSteps: Array<{ stepMatcher: string | RegExp; stepFunction: () => unknown }> = [];
@@ -12,11 +16,16 @@ const registerStep = (stepMatcher: string | RegExp, stepFunction: () => unknown)
 export const createAutoBindSteps = (jestLike: IJestLike) => {
   const defineFeature = createDefineFeature(jestLike);
 
-  return (parsedFeatures: ParsedFeature | ParsedFeature[], stepDefinitions: StepsDefinitionCallbackFunction[]) => {
+  return <C extends NonNullable<unknown> = NonNullable<unknown>>(
+    parsedFeatures: ParsedFeature | ParsedFeature[],
+    stepDefinitions: StepsDefinitionCallbackFunctionWithContext<C>[],
+  ) => {
     let features = parsedFeatures;
     if (!Array.isArray(features)) {
       features = [features];
     }
+
+    const context = {} as C;
 
     stepDefinitions.forEach(stepDefinitionCallback => {
       stepDefinitionCallback({
@@ -29,6 +38,7 @@ export const createAutoBindSteps = (jestLike: IJestLike) => {
         pending: () => {
           // Nothing to do
         },
+        context,
       });
     });
 

--- a/src/feature-definition-creation.ts
+++ b/src/feature-definition-creation.ts
@@ -24,6 +24,11 @@ export type StepsDefinitionCallbackOptions = {
   pending: () => void;
 };
 
+export type StepsDefinitionCallbackOptionsWithContext<C extends NonNullable<unknown> = NonNullable<unknown>> =
+  StepsDefinitionCallbackOptions & {
+    context: C;
+  };
+
 export interface IJestLike {
   describe: jest.Describe;
   test: jest.It;
@@ -44,6 +49,9 @@ export type DefineScenarioFunctionWithAliases = DefineScenarioFunction & {
 };
 
 export type StepsDefinitionCallbackFunction = (options: StepsDefinitionCallbackOptions) => void;
+export type StepsDefinitionCallbackFunctionWithContext<C extends NonNullable<unknown> = NonNullable<unknown>> = (
+  options: StepsDefinitionCallbackOptionsWithContext<C>,
+) => void;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type DefineStepFunction = (stepMatcher: string | RegExp, stepDefinitionCallback: (...args: any[]) => any) => any;
 export type DefineFeatureFunction = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,11 @@ export {
   generateCodeFromFeature,
   generateCodeWithSeparateFunctionsFromFeature,
 } from './code-generation/generate-code-by-line-number';
-export { StepsDefinitionCallbackFunction as StepDefinitions, IJestLike } from './feature-definition-creation';
+export {
+  StepsDefinitionCallbackFunction as StepDefinitions,
+  StepsDefinitionCallbackFunctionWithContext as StepDefinitionsWithContext,
+  IJestLike,
+} from './feature-definition-creation';
 
 const jestLike: IJestLike = {
   describe,


### PR DESCRIPTION
This PR introduces the ability to share context between `steps` and `stepDefinition` files during test execution. This is achieved by using the context to load the necessary information.

Here is an example of how this works:

In the `stepDefinition` function, we initialise a `new VendingMachine()` via `beforeEach`. This allows it to be added to the context, which can then be used directly in steps or even in other `stepDefinition` files.

```typescript
// specs/step-definitions/global-vending-machine-steps.ts
import { StepDefinitionsWithContext } from 'jest-cucumber';

import { VendingMachine } from '../src/vending-machine';

type Context = {
  vendingMachine: VendingMachine;
};

export const globalVendingMachineSteps: StepDefinitionsWithContext<Context> = ({ given, and, when, then, context }) => {
  beforeEach(() => {
    context.vendingMachine = new VendingMachine();
  });
  
  given(/^the vending machine has "(.*)" in stock$/, (itemName: string) => {
    context.vendingMachine.stockItem(itemName, 1);
  });

  and('I have inserted the correct amount of money', () => {
    context.vendingMachine.insertMoney(0.5);
  });

  when(/^I purchase "(.*)"$/, (itemName: string) => {
    context.vendingMachine.dispenseItem(itemName);
  });

  then(/^my "(.*)" should be dispensed$/, (itemName: string) => {
    const inventoryAmount = context.vendingMachine.items[itemName];
    expect(inventoryAmount).toBe(0);
  });
};
```
```typescript
// specs/step-definitions/expect-vending-machine-steps.ts
import { StepDefinitionsWithContext } from 'jest-cucumber';

type Context = {
  vendingMachine: VendingMachine;
};

export const expectVendingMachineSteps: StepDefinitionsWithContext<Context> = ({ given, and, when, then, context }) => {
  then(/^my "(.*)" should be dispensed$/, (itemName: string) => {
    const inventoryAmount = context.vendingMachine.items[itemName];
    expect(inventoryAmount).toBe(0);
  });
};

```