### PR TITLE
Fix regression in loadFeature now corrected to consider global options for relative feature file loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "testMatch": [
-      "**/*.steps.ts"
+      "**/*.{steps,test}.ts"
     ],
     "moduleFileExtensions": [
       "js",

--- a/specs/parsed-feature-loading.test.ts
+++ b/specs/parsed-feature-loading.test.ts
@@ -1,0 +1,18 @@
+import { loadFeature, setJestCucumberConfiguration } from '../src';
+
+describe('loadFeature', () => {
+  it('should not throw an exception when loadFeature is called with loadRelativePath set to true in the global configuration', () => {
+    setJestCucumberConfiguration({
+      loadRelativePath: true,
+    });
+
+    let hasException = false;
+    try {
+      loadFeature('./features/auto-bind-steps.feature');
+    } catch (e) {
+      hasException = true;
+    }
+
+    expect(hasException).toBeFalsy();
+  });
+});

--- a/src/parsed-feature-loading.ts
+++ b/src/parsed-feature-loading.ts
@@ -347,7 +347,8 @@ export const loadFeature = (featureFilePath: string, options?: Options) => {
   const callSite = callsites()[1];
   const fileOfCaller = (callSite && callSite.getFileName()) || '';
   const dirOfCaller = dirname(fileOfCaller);
-  const absoluteFeatureFilePath = resolve(options && options.loadRelativePath ? dirOfCaller : '', featureFilePath);
+  const resolveOptions = getJestCucumberConfiguration(options);
+  const absoluteFeatureFilePath = resolve(resolveOptions.loadRelativePath ? dirOfCaller : '', featureFilePath);
 
   try {
     const featureText: string = readFileSync(absoluteFeatureFilePath, 'utf8');


### PR DESCRIPTION
This PR corrects a regression present since version 4. 

The problem concerned the `loadFeature` function, which threw an exception when `loadRelativePath` was set to `true` via `setJestCucumberConfiguration` in the setupTest file.
