### PR TITLE
Exposing few symbols from configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { createAutoBindSteps } from './automatic-step-binding';
 
 export { loadFeature, loadFeatures, parseFeature } from './parsed-feature-loading';
 export { DefineStepFunction } from './feature-definition-creation';
-export { setJestCucumberConfiguration } from './configuration';
+export { Options, ErrorOptions, ScenarioNameTemplateVars, setJestCucumberConfiguration } from './configuration';
 export {
   generateCodeFromFeature,
   generateCodeWithSeparateFunctionsFromFeature,


### PR DESCRIPTION
I ended up wrapping `#loadFeature` and had to expose its options types. And I'd rather import those from "`jest-cucumber`" instead of "`jest-cucumber/dist/...`" or repeat its definition in my program... :)