### PR TITLE
Enhancement of #scenarioNameTemplate for scenario outlines

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,4 +1,5 @@
 import type { IJestLike } from './feature-definition-creation';
+import { ParsedFeature, ParsedScenario, ParsedScenarioOutline } from './models';
 
 export type ErrorOptions = {
   scenariosMustMatchFeatureFile: boolean;
@@ -16,9 +17,12 @@ export type Options = {
 
 export type ScenarioNameTemplateVars = {
   featureTitle: string;
+  feature: ParsedFeature;
   scenarioTitle: string;
+  scenario: ParsedScenario;
   scenarioTags: string[];
   featureTags: string[];
+  scenarioOutline: ParsedScenarioOutline;
 };
 
 export const defaultErrorSettings = {

--- a/src/feature-definition-creation.ts
+++ b/src/feature-definition-creation.ts
@@ -103,10 +103,13 @@ export const createDefineFeature = (): DefineFeatureFunction => {
         return (
           options &&
           options.scenarioNameTemplate({
+            feature: parsedFeature,
             featureTitle: parsedFeature.title,
             scenarioTitle: scenarioTitle.toString(),
+            scenario: parsedScenario,
             featureTags: parsedFeature.tags,
             scenarioTags: (parsedScenario || parsedScenarioOutline).tags,
+            scenarioOutline: parsedScenarioOutline,
           })
         );
       } catch (err) {
@@ -283,14 +286,16 @@ export const createDefineFeature = (): DefineFeatureFunction => {
 
       const { options } = parsedFeature;
 
-      // eslint-disable-next-line no-param-reassign
-      scenarioTitle = processScenarioTitleTemplate(
-        scenarioTitle,
-        parsedFeature,
-        options,
-        parsedScenario,
-        parsedScenarioOutline,
-      );
+      if (!parsedScenarioOutline) {
+        // eslint-disable-next-line no-param-reassign
+        scenarioTitle = processScenarioTitleTemplate(
+          scenarioTitle,
+          parsedFeature,
+          options,
+          parsedScenario,
+          parsedScenarioOutline,
+        );
+      }
 
       ensureFeatureFileAndStepDefinitionScenarioHaveSameSteps(
         options,
@@ -319,6 +324,15 @@ export const createDefineFeature = (): DefineFeatureFunction => {
         );
       } else if (parsedScenarioOutline) {
         parsedScenarioOutline.scenarios.forEach(scenario => {
+          // eslint-disable-next-line no-param-reassign
+          scenarioTitle = processScenarioTitleTemplate(
+            scenarioTitle,
+            parsedFeature,
+            options,
+            parsedScenario,
+            parsedScenarioOutline,
+          );
+
           defineScenario(
             scenario.title || scenarioTitle,
             scenarioFromStepDefinitions,


### PR DESCRIPTION
Today, given a scenario outline containing multiple scenarios, `#scenarioNameTemplate` (available as an option) would always be called once before the first scenario is even touched. Then, iteratively, for every scenario, it would not be called again at all. So, proposed changes include :
- Not calling `#scenarioNameTemplate` once before scenarios are actually iterated over;
- Call it after for every scenario in the outline;
- Passing feature, scenario and outline to the function for better control over the title it can produce (here, I only needed the `ParsedScenario` instance but since the other two are available they might be useful sometimes too).

Example feature:

```
Feature: Number Utility

  Scenario Template: with number <NUMBER> (<PRECISION>) → <RESULT>
    Given number <NUMBER>
    And precision <PRECISION>
    When #round is called
    Then result should be <RESULT>

    Examples:
      | NUMBER            | RESULT      | PRECISION |
      |             0.000 |           0 |           |
      |             1.255 |        1.26 |         2 |
      ...
```

For every scenario/example, `scenarioTitle` is today "`with number <NUMBER> (<PRECISION>) → <RESULT>`".
With proposed changes, this doesn't change but the actual scenario/example's title is reachable with `scenario.title` (which is, for example, "`with number 0.000 () → 0`" for the first scenario). FYI my name template is as follows:

```
scenarioNameTemplate: (variables) =>
      variables.scenarioTitle.replace('() →', '→'),
```