### PR TITLE
Adding additional characters to tag filter regex

### DIFF
--- a/src/tag-filtering.ts
+++ b/src/tag-filtering.ts
@@ -5,7 +5,7 @@ type TagFilterFunction = (tags: string[]) => boolean;
 const cachedTagFilterFunctions: { [tag: string]: TagFilterFunction } = {};
 
 const convertTagFilterExpressionToFunction = (tagFilterExpression: string) => {
-  const tagRegex = /(@[A-Za-z-_0-9]+)/g;
+  const tagRegex = /(@[A-Za-z-_.0-9]+)/g;
   const tags: string[] = [];
   let match: RegExpMatchArray | null = null;
   let newTagFilterExpression = `${tagFilterExpression}`;


### PR DESCRIPTION
Fixing an issue when `tagFilter` value in `setJestCucumberConfiguration` was set with dot characters, e.g.

```js
setJestCucumberConfiguration({ tagFilter: '@10.2.2_1' });
```

causing following error

```
Error: Could not parse tag filter "@10.2.2_1"
 ❯ convertTagFilterExpressionToFunction node_modules/jest-cucumber/src/tag-filtering.ts:40:11
 ❯ checkIfScenarioMatchesTagFilter node_modules/jest-cucumber/src/tag-filtering.ts:59:25
 ❯ setScenarioSkipped node_modules/jest-cucumber/src/tag-filtering.ts:67:32
 ❯ node_modules/jest-cucumber/src/tag-filtering.ts:84:61
 ❯ applyTagFilters node_modules/jest-cucumber/src/tag-filtering.ts:84:45
 ❯ defineFeature node_modules/jest-cucumber/src/feature-definition-creation.ts:383:63
 ❯ node_modules/jest-cucumber/src/automatic-step-binding.ts:44:7
 ❯ Proxy.<anonymous> node_modules/jest-cucumber/src/automatic-step-binding.ts:43:14
```

Example of tag with dots from official cucumber documentation:
https://cucumber.io/docs/cucumber/api/?lang=javascript#using-tags-for-documentation